### PR TITLE
Update LICENSE year to 2025 under GSSoC'25

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Mehul Prajapati
+Copyright (c) 2025 Mehul Prajapati
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### 🔗 Related Issue
- Closes: #118

---

### 📄 Description
This PR updates the year in the existing MIT LICENSE file from **2024 to 2025**, reflecting the current copyright year.

Maintaining an up-to-date license ensures clarity regarding the legal rights for usage and contribution.

---

### ✅ How Has This Been Tested?
- Verified that the LICENSE file is correctly updated.
- Confirmed proper formatting of the MIT License content.
- File appears at the root of the project, replacing the old license.

---

### 🖼️ Screenshots (if applicable)
*Not applicable — text-only file update.*

---

### 🧩 Type of Change

- [x] Documentation update

---

### 🎯 Program
Contributed under **GSSoC'25**.

---
