### PR TITLE
Fix: Persist theme selection using localStorage

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -10,7 +10,11 @@ interface ThemeContextType {
 export const ThemeContext = createContext<ThemeContextType | null>(null);
 
 const ThemeWrapper = ({ children }: { children: ReactNode }) => {
-  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const [mode, setMode] = useState<'light' | 'dark'>(() => {
+  const savedMode = localStorage.getItem('theme');
+  return savedMode === 'dark' ? 'dark' : 'light';
+});
+
 
   useEffect(() => {
     if (mode === 'dark') {
@@ -18,6 +22,7 @@ const ThemeWrapper = ({ children }: { children: ReactNode }) => {
     } else {
       document.documentElement.classList.remove('dark');
     }
+    localStorage.setItem('theme', mode);
   }, [mode]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
### Related Issue
- Closes: #158 

---

### Description
This PR adds persistence to the selected theme (light/dark) using `localStorage`.  
When the user selects a theme, it will now be saved and retained even after refreshing or reopening the application.

---

### How Has This Been Tested?
- Manually tested by switching themes and reloading the app.
- Verified that the last selected theme is applied on reload.
- Confirmed no visual or functional regressions in theme toggle.

---

### Screenshots (if applicable)
N/A – no visual change, just persistence across reloads.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now remembers your selected theme (light or dark mode) across sessions.

* **Bug Fixes**
  * Improved reliability of theme selection by ensuring the correct mode is restored on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->