### PR TITLE
Fixed merged PR filter shows less than 10 entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
+    "@octokit/rest": "^22.0.0",
     "@primer/octicons-react": "^19.15.5",
     "@vitejs/plugin-react": "^4.3.3",
     "axios": "^1.7.7",

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -1,15 +1,18 @@
 import { useState, useMemo } from 'react';
-import { Octokit } from '@octokit/core';
+import { Octokit } from '@octokit/rest';
 
 export const useGitHubAuth = () => {
   const [username, setUsername] = useState('');
   const [token, setToken] = useState('');
   const [error, setError] = useState('');
 
+  // FIX: The Octokit instance only depends on the token for authentication.
   const octokit = useMemo(() => {
-    if (!username || !token) return null;
+    // Only create an instance if a token exists.
+    if (!token) return null;
+    
     return new Octokit({ auth: token });
-  }, [username, token]);
+  }, [token]); // Dependency array should only contain `token`.
 
   const getOctokit = () => octokit;
 


### PR DESCRIPTION
### Related Issue
- Closes: #174

---

### Details of Fix
- To fix the issue, passed the filter state to the API query itself. 
- This way, we ask the API directly for "10 merged pull requests," ensuring each page is full.
- Removed the state-based filtering, as the API will now handle it.
 
---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced filtering options for issues and pull requests, allowing users to filter by state (such as open, closed, merged) directly via the interface.
* **Improvements**
  * Improved accuracy and responsiveness of data fetching when navigating between tabs or changing filters.
  * More reliable display and pagination of issues and pull requests.
* **Bug Fixes**
  * Resolved redundant data fetching on initial page load.
* **Chores**
  * Updated internal dependencies for improved GitHub API support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->