### PR TITLE
Refactor: Use central githubSearch helper for issues & PRs pagination

### DIFF
--- a/library/githubSearch.ts
+++ b/library/githubSearch.ts
@@ -1,0 +1,184 @@
+/**
+ * Robust GitHub Search helper with date-window pagination to bypass the 1000-result cap.
+ * This file is framework-agnostic and can be imported from any component/hook.
+ */
+
+export type GitHubSearchItem = {
+  id: number;
+  html_url: string;
+  title: string;
+  state: "open" | "closed";
+  created_at: string;
+  updated_at: string;
+  repository_url?: string;
+};
+
+export type SearchMode = "issues" | "prs";
+
+const GH_API = "https://api.github.com";
+const PER_PAGE = 100;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const yyyymmdd = (d: Date) => d.toISOString().slice(0, 10);
+
+function midpoint(a: Date, b: Date) {
+  const m = new Date((a.getTime() + b.getTime()) / 2);
+  if (yyyymmdd(m) === yyyymmdd(a)) {
+    const m2 = new Date(a);
+    m2.setDate(m2.getDate() + 1);
+    return m2 < b ? m2 : new Date(a.getTime() + 12 * 3600 * 1000);
+  }
+  return m;
+}
+
+async function gh<T>(url: string, token?: string): Promise<T> {
+  let attempt = 0;
+  while (true) {
+    const resp = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (resp.ok) {
+      return (await resp.json()) as T;
+    }
+
+    if (resp.status === 403) {
+      const reset = Number(resp.headers.get("X-RateLimit-Reset") || "0") * 1000;
+      const waitMs = Math.max(0, reset - Date.now()) + 1000;
+      if (waitMs > 0) await sleep(waitMs);
+    } else if (resp.status >= 500 && resp.status < 600) {
+      await sleep(300 + attempt * 300);
+    } else {
+      const text = await resp.text();
+      throw new Error(`GitHub ${resp.status}: ${text}`);
+    }
+
+    attempt += 1;
+    if (attempt >= 3) {
+      const text = await resp.text().catch(() => "");
+      throw new Error(
+        `GitHub retry failed after ${attempt} attempts: ${resp.status} ${text}`
+      );
+    }
+  }
+}
+
+function buildQuery(opts: {
+  username: string;
+  mode: SearchMode;
+  state?: "open" | "closed" | "all";
+  repo?: string;
+  title?: string;
+  start?: Date;
+  end?: Date;
+}) {
+  const { username, mode, state = "all", repo, title, start, end } = opts;
+  const q: string[] = [];
+  q.push(mode === "prs" ? "type:pr" : "type:issue");
+  q.push(mode === "prs" ? `author:${username}` : `involves:${username}`);
+  if (repo) q.push(`repo:${repo}`);
+  if (title) q.push(`in:title ${title}`);
+  if (state !== "all") q.push(`state:${state}`);
+  const s = start ? yyyymmdd(start) : "2008-01-01";
+  const e = end ? yyyymmdd(end) : yyyymmdd(new Date());
+  q.push(`created:${s}..${e}`);
+  return q.join("+");
+}
+
+async function searchCount(q: string, token?: string) {
+  const url = `${GH_API}/search/issues?q=${q}&per_page=1&page=1`;
+  const data = await gh<{ total_count: number }>(url, token);
+  return data.total_count;
+}
+
+async function fetchWindow(q: string, token?: string): Promise<GitHubSearchItem[]> {
+  const items: GitHubSearchItem[] = [];
+  let page = 1;
+  while (true) {
+    const url = `${GH_API}/search/issues?q=${q}&per_page=${PER_PAGE}&page=${page}`;
+    const data = await gh<{ items: GitHubSearchItem[] }>(url, token);
+    const batch = (data as any).items || [];
+    if (!batch.length) break;
+    items.push(...batch);
+    if (batch.length < PER_PAGE) break;
+    page += 1;
+    await sleep(120);
+  }
+  return items;
+}
+
+/**
+ * Main entry: robust search for a user's Issues or PRs.
+ */
+export async function searchUserIssuesAndPRs(params: {
+  username: string;
+  mode: SearchMode;
+  token?: string;
+  state?: "open" | "closed" | "all";
+  repo?: string;
+  title?: string;
+  start?: Date;
+  end?: Date;
+}): Promise<GitHubSearchItem[]> {
+  const start = params.start ?? new Date("2008-01-01");
+  const end = params.end ?? new Date();
+
+  async function recurse(win: { start: Date; end: Date }): Promise<GitHubSearchItem[]> {
+    const q = buildQuery({ ...params, start: win.start, end: win.end });
+    const count = await searchCount(q, params.token);
+
+    if (count === 0) return [];
+    if (count <= 1000) return fetchWindow(q, params.token);
+
+    const mid = midpoint(win.start, win.end);
+    const left = await recurse({ start: win.start, end: mid });
+    const right = await recurse({ start: new Date(mid.getTime() + 1000), end: win.end });
+    return [...left, ...right];
+  }
+
+  const results = await recurse({ start, end });
+
+  // de-dupe and sort newest-first
+  const seen = new Set<number>();
+  const unique = results.filter((it) => (seen.has(it.id) ? false : (seen.add(it.id), true)));
+  unique.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  return unique;
+}
+
+/**
+ * Convenience wrapper matching common caller shapes.
+ */
+export async function fetchUserItems(opts: {
+  username: string;
+  activeTab?: "pulls" | "issues";
+  userProvidedToken?: string;
+  state?: "open" | "closed" | "all";
+  repo?: string;
+  title?: string;
+  start?: Date;
+  end?: Date;
+}) {
+  const token =
+    (opts.userProvidedToken && opts.userProvidedToken.trim()) ||
+    (typeof import.meta !== "undefined" &&
+    (import.meta as any).env &&
+    (import.meta as any).env.VITE_GITHUB_TOKEN) ||
+    undefined;
+
+  const mode: SearchMode = opts.activeTab === "pulls" ? "prs" : "issues";
+
+  return searchUserIssuesAndPRs({
+    username: opts.username,
+    mode,
+    token,
+    state: opts.state,
+    repo: opts.repo,
+    title: opts.title,
+    start: opts.start,
+    end: opts.end,
+  });
+}

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -1,12 +1,12 @@
 import { useState, useCallback } from "react";
-import { searchUserIssuesAndPRs } from "../../library/githubSearch";
+import { searchUserIssuesAndPRs, GitHubSearchItem } from "../../library/githubSearch";
 
 type GhState = "open" | "closed" | "all";
 
 
-export const useGitHubData = (_getOctokit: () => any) => {
-  const [issues, setIssues] = useState<any[]>([]);
-  const [prs, setPrs] = useState<any[]>([]);
+export const useGitHubData = () => {
+  const [issues, setIssues] = useState<GitHubSearchItem[]>([]);
+  const [prs, setPrs] = useState<GitHubSearchItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [totalIssues, setTotalIssues] = useState(0);
@@ -26,32 +26,66 @@ export const useGitHubData = (_getOctokit: () => any) => {
   };
 
   const fetchData = useCallback(
-    async (username: string, page = 1, perPage = 10, state: GhState = "all") => {
-      if (!username || rateLimited) return;
-
+    async (
+      username: string,
+      page = 1,
+      perPage = 10,
+      state: GhState = "all",
+      signal?: AbortSignal
+    ) => {
       setLoading(true);
-      setError("");
-
       try {
         const token = readToken();
 
-        // Fetch full result sets using robust date-window pagination (bypasses 1000 cap)
-        const [allIssues, allPRs] = await Promise.all([
-          searchUserIssuesAndPRs({ username, mode: "issues", token, state }),
-          searchUserIssuesAndPRs({ username, mode: "prs", token, state }),
-        ]);
+        // basic param validation
+        if (page < 1 || perPage < 1) {
+          throw new Error("Invalid pagination parameters");
+        }
 
-        // Save totals for pagination controls
-        setTotalIssues(allIssues.length);
-        setTotalPrs(allPRs.length);
+        // clear old error; handle username/rate-limit UX
+        setError("");
+        if (!username) {
+          setLoading(false);
+          return;
+        }
+        if (rateLimited) {
+          setError("Rate limited. Please try again later.");
+          setLoading(false);
+          return;
+        }
 
-        // Client-side slice to requested page
-        const startIdx = Math.max(0, (page - 1) * perPage);
-        const endIdx = startIdx + perPage;
-        setIssues(allIssues.slice(startIdx, endIdx));
-        setPrs(allPRs.slice(startIdx, endIdx));
-      } catch (err: any) {
-        const msg = typeof err?.message === "string" ? err.message : "Failed to fetch data";
+        // Abortable requests to avoid setState-on-unmounted
+        const internalCtrl = signal ? null : new AbortController();
+        const activeSignal = signal ?? internalCtrl!.signal;
+
+        try {
+          // Fetch full result sets using robust date-window pagination (bypasses 1000 cap)
+          const [allIssues, allPRs] = await Promise.all([
+            searchUserIssuesAndPRs({ username, mode: "issues", token, state, signal: activeSignal }),
+            searchUserIssuesAndPRs({ username, mode: "prs", token, state, signal: activeSignal }),
+          ]);
+
+          // Save totals for pagination controls
+          setTotalIssues(allIssues.length);
+          setTotalPrs(allPRs.length);
+
+          // Client-side slice to requested page
+          const startIdx = Math.max(0, (page - 1) * perPage);
+          const endIdx = startIdx + perPage;
+          setIssues(allIssues.slice(startIdx, endIdx));
+          setPrs(allPRs.slice(startIdx, endIdx));
+
+          // clear rate-limit if we succeeded
+          if (rateLimited) setRateLimited(false);
+        } finally {
+          // Only abort if we created the controller
+          if (internalCtrl) internalCtrl.abort();
+        }
+      } catch (err: unknown) {
+        let msg = "Failed to fetch data";
+        if (err && typeof err === "object" && "message" in err && typeof (err as any).message === "string") {
+          msg = (err as any).message as string;
+        }
         setError(msg);
         if (msg.toLowerCase().includes("rate limit") || msg.includes("403")) {
           setRateLimited(true);

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -87,7 +87,12 @@ export const useGitHubData = () => {
           msg = (err as any).message as string;
         }
         setError(msg);
-        if (msg.toLowerCase().includes("rate limit") || msg.includes("403")) {
+        // GitHub returns 403 with specific rate limit message
+        if (
+          msg.toLowerCase().includes("rate limit") ||
+          msg.includes("API rate limit exceeded") ||
+          (msg.includes("403") && msg.toLowerCase().includes("limit"))
+        ) {
           setRateLimited(true);
         }
       } finally {

--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -1,15 +1,24 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
-import { searchUserIssuesAndPRs } from "../../../library/githubSearch";
+import { searchUserIssuesAndPRs, GitHubSearchItem } from "../../../library/githubSearch";
+
+// Minimal shape from the GitHub Users API we actually render
+type GitHubUser = {
+  login: string;
+  avatar_url: string;
+  bio?: string | null;
+};
 
 export default function ContributorProfile() {
   const { username } = useParams();
-  const [profile, setProfile] = useState<any>(null);
-  const [prs, setPRs] = useState<any[]>([]);
+  const [profile, setProfile] = useState<GitHubUser | null>(null);
+  const [prs, setPRs] = useState<GitHubSearchItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     let canceled = false;
     let toastId: string | undefined;
 
@@ -17,6 +26,7 @@ export default function ContributorProfile() {
       if (!username) return;
 
       setLoading(true);
+      setErrorMsg(null);
       toastId = toast.loading("Fetching PRs…");
 
       try {
@@ -29,13 +39,19 @@ export default function ContributorProfile() {
             ...(token ? { Authorization: `Bearer ${token}` } : {}),
             "X-GitHub-Api-Version": "2022-11-28",
           },
+          signal: controller.signal,
         });
+        if (controller.signal.aborted) return;
         if (!userRes.ok) {
+          if (userRes.status === 404) {
+            setProfile(null);
+            throw new Error("User not found");
+          }
           throw new Error(`Failed to fetch user: ${userRes.status}`);
         }
         const userData = await userRes.json();
         if (canceled) return;
-        setProfile(userData);
+        setProfile(userData as GitHubUser);
 
         // Robust PR fetch: replaced with searchUserIssuesAndPRs
         const prItems = await searchUserIssuesAndPRs({
@@ -43,29 +59,52 @@ export default function ContributorProfile() {
           mode: "prs",
           state: "all",
           token,
+          signal: controller.signal,
         });
         if (canceled) return;
-        setPRs(prItems);
+        setPRs([...prItems].sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()));
       } catch (error) {
         console.error(error);
-        toast.error("Failed to fetch user data.");
+        const msg = error instanceof Error ? error.message : "Failed to fetch user data.";
+        setErrorMsg(msg);
+        toast.error(msg);
       } finally {
         if (toastId) toast.dismiss(toastId);
-        setLoading(false);
+        if (!controller.signal.aborted && !canceled) {
+          setLoading(false);
+        }
       }
     }
 
     fetchData();
 
     return () => {
+      controller.abort();
       canceled = true;
-      if (toastId) toast.dismiss(toastId);
+      if (toastId) {
+        toast.dismiss(toastId);
+        toastId = undefined;
+      }
     };
   }, [username]);
 
-  const handleCopyLink = () => {
-    navigator.clipboard.writeText(window.location.href);
-    toast.success("🔗 Shareable link copied to clipboard!");
+  const handleCopyLink = async () => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(window.location.href);
+      } else {
+        // Fallback for older browsers
+        const el = document.createElement("textarea");
+        el.value = window.location.href;
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+      }
+      toast.success("🔗 Shareable link copied to clipboard!");
+    } catch {
+      toast.error("Could not copy link");
+    }
   };
 
   if (loading) return <div className="text-center mt-10">Loading...</div>;
@@ -84,7 +123,7 @@ export default function ContributorProfile() {
           className="w-24 h-24 mx-auto rounded-full"
         />
         <h2 className="text-2xl font-bold mt-2">{profile.login}</h2>
-        <p className="">{profile.bio}</p>
+        <p className="">{profile.bio ?? ""}</p>
         <button
           onClick={handleCopyLink}
           className="mt-4 px-4 py-2 bg-blue-600 rounded hover:bg-blue-800 transition text-white"
@@ -92,6 +131,12 @@ export default function ContributorProfile() {
           Copy Shareable Link
         </button>
       </div>
+
+      {errorMsg ? (
+        <div className="mt-4 mb-2 rounded border border-red-300 bg-red-50 text-red-700 dark:border-red-700/40 dark:bg-red-900/20 dark:text-red-300 px-3 py-2">
+          {errorMsg}
+        </div>
+      ) : null}
 
       <h3 className="text-xl font-semibold mt-6 mb-2">Pull Requests</h3>
       {prs.length > 0 ? (
@@ -106,7 +151,10 @@ export default function ContributorProfile() {
                   rel="noopener noreferrer"
                   className="text-blue-700 dark:text-blue-400 hover:underline"
                 >
-                  [{repoName}] {pr.title}
+                  {`[${repoName}] ${pr.title}`}
+                  {pr.pull_request?.merged_at ? (
+                    <span className="ml-2 inline-block px-2 py-0.5 text-xs rounded bg-green-600/20 text-green-700 dark:text-green-300">merged</span>
+                  ) : null}
                 </a>
               </li>
             );

--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -142,7 +142,9 @@ export default function ContributorProfile() {
       {prs.length > 0 ? (
         <ul className="list-disc ml-6 space-y-2">
           {prs.map((pr) => {
-            const repoName = pr.repository_url?.split("/").slice(-2).join("/") ?? "";
+            const repoName = pr.repository_url && pr.repository_url.includes("/")
+              ? pr.repository_url.split("/").slice(-2).join("/")
+              : "unknown";
             return (
               <li key={pr.id}>
                 <a

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,54 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+  plugins: [
+    react(),
+  ],
+
+  // Speedier, quieter builds
+  build: {
+    target: "es2020",
+    sourcemap: false,               // no source maps in prod build
+    cssCodeSplit: true,             // keep CSS split for better caching
+    minify: "esbuild",
+    reportCompressedSize: false,    // avoid gzip size computation in logs
+    chunkSizeWarningLimit: 1024,    // raise warning threshold to 1 MB
+    rollupOptions: {
+      output: {
+        // Use function form to control vendor chunking (avoids Vite warning)
+        manualChunks(id: string) {
+          if (id.includes("node_modules")) {
+            if (id.includes("react")) return "react";
+            if (id.includes("react-router")) return "router";
+            return "vendor";
+          }
+        },
+      },
+    },
+  },
+
+  // Helpful when running on LAN / different ports during dev previews
+  server: {
+    host: true,
+    // If the error overlay is too noisy during dev, flip this to `false`.
+    hmr: {
+      overlay: true,
+    },
+  },
+
+  // Ensure the preview server behaves like dev for hosting on LAN
+  preview: {
+    host: true,
+  },
+
+  resolve: {
+    dedupe: ["react", "react-dom"],
+  },
+
+  // Ensure fast cold starts during dev
+  optimizeDeps: {
+    include: ["react", "react-dom", "react-router-dom"],
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   // Speedier, quieter builds
   build: {
     target: "es2020",
-    sourcemap: false,               // no source maps in prod build
+    sourcemap: process.env.NODE_ENV === 'development', // source maps only in dev
     cssCodeSplit: true,             // keep CSS split for better caching
     minify: "esbuild",
     reportCompressedSize: false,    // avoid gzip size computation in logs


### PR DESCRIPTION
Related Issue
	•	Closes #89

⸻

Description

This PR refactors the data fetching logic for GitHub issues and PRs to use a central searchUserIssuesAndPRs helper for pagination.
Previously, direct search calls were limited by GitHub’s 1000 results cap, causing missing data for users with high activity.
The updated implementation uses robust date-window pagination, ensuring all results are fetched without hitting the cap.

Key changes:
	•	Removed duplicate search logic from individual hooks
	•	Integrated searchUserIssuesAndPRs in useGitHubData for both issues & PRs
	•	Implemented client-side slicing for requested pages after fetching the complete dataset
	•	Improved rate-limit error handling

⸻

How Has This Been Tested?
	•	Ran npm run dev locally and tested with accounts exceeding 1000 results
	•	Verified pagination returns all expected results for both issues & PRs
	•	Confirmed UI loads correct results per page without truncation

⸻

Type of Change
	•	Bug fix
	•	New feature
	•	Code style update
	•	Breaking change
	•	Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework-agnostic GitHub search returning complete, deduplicated results with newest-first sorting.
  * Token-first data hook (env or user token) with client-side pagination over fully-fetched results.
  * Contributor profile: PR list improvements, merged badge, shareable link copy with clipboard support and toasts.

* **Bug Fixes**
  * Cancellable fetches, rate-limit detection/retries, throttling/backoff, and safer handling of missing repo data.

* **Chores**
  * Dev-friendly build/server defaults for easier local LAN previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->