### PR TITLE
Fix: moved Github ID & Token to environmental variable

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect } from 'react'
 import {
   IssueOpenedIcon,
   IssueClosedIcon,
@@ -156,6 +156,7 @@ const Home: React.FC = () => {
   const totalCount = tab === 0 ? totalIssues : totalPrs;
 
   return (
+
     <Container maxWidth="lg" sx={{ mt: 4, minHeight: "80vh", color: theme.palette.text.primary }}>
       {/* Auth Form */}
       <Paper elevation={1} sx={{ p: 2, mb: 4, backgroundColor: theme.palette.background.paper }}>
@@ -277,65 +278,63 @@ const Home: React.FC = () => {
         </Box>
       ) : (
         <Box sx={{ maxHeight: "400px", overflowY: "auto" }}>
-
-          <TableContainer component={Paper}>
-
-            <Table size="small">
-
-              <TableHead>
-                <TableRow>
-                  <TableCell>Title</TableCell>
-                  <TableCell align="center">Repository</TableCell>
-                  <TableCell align="center">State</TableCell>
-                  <TableCell>Created</TableCell>
-                </TableRow>
-              </TableHead>
-
-              <TableBody>
-                {currentFilteredData.map((item) => (
-                  <TableRow key={item.id}>
-
-                    <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        {getStatusIcon(item)}
-                        <Link
-                            href={item.html_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            underline="hover"
-                            sx={{ color: theme.palette.primary.main }}
-                        >
-                            {item.title}
-                        </Link>
-                    </TableCell>
-
-
-                    <TableCell align="center">
-                      {item.repository_url.split("/").slice(-1)[0]}
-                    </TableCell>
-
-                    <TableCell align="center">
-                      {item.pull_request?.merged_at ? "merged" : item.state}
-                    </TableCell>
-
-                    <TableCell>{formatDate(item.created_at)}</TableCell>
-
-                  </TableRow>
-                ))}
-              </TableBody>
-
-            </Table>
-
-            <TablePagination
-              component="div"
-              count={totalCount}
-              page={page}
-              onPageChange={handlePageChange}
-              rowsPerPage={ROWS_PER_PAGE}
-              rowsPerPageOptions={[ROWS_PER_PAGE]}
-            />
-
-          </TableContainer>
+             {currentFilteredData.length === 0 ? (
+            <Box textAlign="center" my={4} color="gray">
+         <p>
+           {tab === 0
+             ? "No issues found for this user."
+             : "No pull requests found for this user."}
+          </p>
         </Box>
+  ) : (
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+            <TableCell align="center">Repository</TableCell>
+            <TableCell align="center">State</TableCell>
+            <TableCell>Created</TableCell>
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          {currentFilteredData.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                {getStatusIcon(item)}
+                <Link
+                  href={item.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                  sx={{ color: theme.palette.primary.main }}
+                >
+                  {item.title}
+                </Link>
+              </TableCell>
+              <TableCell align="center">
+                {item.repository_url.split("/").slice(-1)[0]}
+              </TableCell>
+              <TableCell align="center">
+                {item.pull_request?.merged_at ? "merged" : item.state}
+              </TableCell>
+              <TableCell>{formatDate(item.created_at)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <TablePagination
+        component="div"
+        count={totalCount}
+        page={page}
+        onPageChange={handlePageChange}
+        rowsPerPage={ROWS_PER_PAGE}
+        rowsPerPageOptions={[ROWS_PER_PAGE]}
+      />
+    </TableContainer>
+      )}
+    </Box>
       )}
     </Container>
   );


### PR DESCRIPTION
Solve Issue no #197 

### Summary
This PR fixes the empty state issue in the Issues/PRs tab.
Now, instead of showing an empty table with pagination, the UI displays
a clear message when no data is available.

### Changes Made
- Added conditional rendering in Issues.tsx.
- Show "No issues found" or "No pull requests found" message.
- Table + pagination now render only when data exists.

### Testing
- Tested locally using a dummy GitHub ID and personal access token in `.env`.
- The app now fetches data correctly without exposing secrets.
![Screenshot_24-8-2025_0913_localhost](https://github.com/user-attachments/assets/1eb61120-adae-414b-98c2-1f77c6fac55a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab-aware empty-state messaging in the Tracker list, showing clear messages when no results are found for issues or pull requests.
  * Improved UX by hiding the table and pagination when no results are available, reducing visual clutter.
  * No changes to normal behavior: when results exist, the same table and pagination are displayed as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->