### PR TITLE
fix: 'closed' filter behavior in PR section

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -101,11 +101,18 @@ const Home: React.FC = () => {
   const filterData = (data: GitHubItem[], filterType: string): GitHubItem[] => {
     let filtered = [...data];
     if (["open", "closed", "merged"].includes(filterType)) {
-      filtered = filtered.filter((item) =>
-        filterType === "merged"
-          ? !!item.pull_request?.merged_at
-          : item.state === filterType
-      );
+      filtered = filtered.filter((item) => {
+        if (filterType === "merged") {
+          return !!item.pull_request?.merged_at
+        }
+        else if (filterType === "closed") {
+          return item.state === "closed" && !item.pull_request?.merged_at
+        }
+        else {
+          //open
+          return item.state === "open"
+        }
+      });
     }
     if (searchTitle) {
       filtered = filtered.filter((item) =>


### PR DESCRIPTION
### Related Issue
- Closes: #166 

---

### Description

Updated the pull request filtering logic to ensure that closed only includes PRs that are closed but not merged, 
and merged only includes PRs that have been merged.

---

### Screenshots 

- Before fix:

<img width="1905" height="906" alt="Screenshot 2025-08-29 002426" src="https://github.com/user-attachments/assets/853f4429-a82b-40af-96dc-aafd80a430d1" />

- After fix:

<img width="1904" height="905" alt="Screenshot 2025-08-29 002503" src="https://github.com/user-attachments/assets/b27ef8ec-f802-4136-a192-01ebceb58a4e" />
<img width="1908" height="910" alt="Screenshot 2025-08-29 002706" src="https://github.com/user-attachments/assets/e8540e0e-7b2e-413b-a1d3-8eaeb116f0e5" />



---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Tracker filters to treat Open, Closed, and Merged as distinct categories. Open now shows only open items; Closed shows only non-merged closed items; Merged shows only merged pull requests. This prevents merged items from appearing under Closed and improves accuracy of filtered results. Other filters (search, repository, date range) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->