### PR TITLE
Solved the broken progress bar issue

### DIFF
--- a/src/components/ScrollProgressBar.tsx
+++ b/src/components/ScrollProgressBar.tsx
@@ -5,11 +5,20 @@ const ScrollProgressBar = () => {
   const [isAnimating, setIsAnimating] = useState(true); // Tracks if the page load animation is active
 
   const handleScroll = () => {
-    const scrollTop = document.documentElement.scrollTop;
-    const scrollHeight =
-      document.documentElement.scrollHeight -
-      document.documentElement.clientHeight;
-    const width = (scrollTop / scrollHeight) * 100;
+    const { documentElement } = document;
+    const scrollTop = documentElement.scrollTop;
+    const scrollableHeight =
+      documentElement.scrollHeight - documentElement.clientHeight;
+
+    if (scrollableHeight <= 0) {
+      setScrollWidth(0);
+      return;
+    }
+
+    const width = Math.min(
+      100,
+      Math.max(0, (scrollTop / scrollableHeight) * 100),
+    );
     setScrollWidth(width);
   };
 

--- a/src/components/ScrollProgressBar.tsx
+++ b/src/components/ScrollProgressBar.tsx
@@ -4,16 +4,6 @@ const ScrollProgressBar = () => {
   const [scrollWidth, setScrollWidth] = useState(0);
   const [isAnimating, setIsAnimating] = useState(true); // Tracks if the page load animation is active
 
-  useEffect(() => {
-    // Simulate the page load animation
-    const animationTimeout = setTimeout(() => {
-      setIsAnimating(false); // End the animation after 2 seconds
-    }, 2000);
-
-    // Clean up timeout
-    return () => clearTimeout(animationTimeout);
-  }, []);
-
   const handleScroll = () => {
     const scrollTop = document.documentElement.scrollTop;
     const scrollHeight =
@@ -24,11 +14,22 @@ const ScrollProgressBar = () => {
   };
 
   useEffect(() => {
-    if (!isAnimating) {
-      window.addEventListener("scroll", handleScroll);
-    }
+    // Simulate the page load animation
+    const animationTimeout = setTimeout(() => {
+      setIsAnimating(false); // End the animation after 2 seconds
+    }, 2000);
+
+    // Clean up timeout
+    return () => clearTimeout(animationTimeout);
+  }, []);
+
+  useEffect(() => {
+    // Always listen for scroll events
+    window.addEventListener("scroll", handleScroll);
+    // Call handleScroll once on mount to set initial position
+    handleScroll();
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [isAnimating]);
+  }, []);
 
   return (
     <>
@@ -56,10 +57,10 @@ const ScrollProgressBar = () => {
             top: 0,
             left: 0,
             width: `${scrollWidth}%`,
-            height: "5px", // Thicker line for scroll progress
-            backgroundColor: "grey",
+            height: "3px",
+            backgroundColor: "#3b82f6",
             zIndex: 100,
-            transition: "width 0.2s ease",
+            transition: "width 0.1s ease",
           }}
         />
       )}


### PR DESCRIPTION
### Related Issue
- Closes: #222 

---

### Description
I've fixed the scroll progress bar functionality on the navbar. The progress bar had several issues that prevented it from working properly:

1. **Scroll listener delay** - The scroll event listener was only being added after the 2-second page load animation completed, so it missed tracking scroll changes during that time
2. **No initial position** - The scroll progress width wasn't being calculated on component mount, so users wouldn't see progress until they actually scrolled
3. **Poor visibility** - The grey color was difficult to see against the navbar background

I've resolved these by:
- Activating the scroll listener immediately on component mount
- Calling `handleScroll()` on mount to capture the initial scroll position
- Changing the color to a more visible blue (#3b82f6)
- Improving the transition smoothness (0.1s instead of 0.2s)

---

### How Has This Been Tested?
I've manually tested by:
- Scrolling up and down the page to verify the blue progress bar fills proportionally
- Checking that the bar starts tracking immediately on page load
- Verifying the initial 2-second animation still displays correctly before switching to scroll tracking

---

### Screenshots (if applicable)
N/A

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scroll progress bar now initializes and updates immediately on load and correctly handles pages with no scrollable content.

* **Style**
  * Updated progress bar appearance: reduced height, changed color to blue (`#3b82f6`), and refined the width transition timing for smoother updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->