### PR TITLE
Enhancement: Enable Public Repo Tracking Without Personal Access Token (PAT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
-    "@primer/octicons-react": "^19.15.5",
+    "@primer/octicons-react": "^19.25.0",
     "@vitejs/plugin-react": "^4.3.3",
     "axios": "^1.7.7",
     "framer-motion": "^12.23.12",

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -7,8 +7,11 @@ export const useGitHubAuth = () => {
   const [error, setError] = useState('');
 
   const octokit = useMemo(() => {
-    if (!username || !token) return null;
+    if (!username) return null;
+    if(token){
     return new Octokit({ auth: token });
+    }
+    return new Octokit();
   }, [username, token]);
 
   const getOctokit = () => octokit;

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -30,7 +30,7 @@ export const useGitHubData = (getOctokit: () => any) => {
         
       const octokit = getOctokit();
 
-      if (!octokit || !username || rateLimited) return;
+      if (!octokit || !username) return;
 
       setLoading(true);
       setError('');
@@ -45,18 +45,27 @@ export const useGitHubData = (getOctokit: () => any) => {
         setPrs(prRes.items);
         setTotalIssues(issueRes.total);
         setTotalPrs(prRes.total);
+        setRateLimited(false);
       } catch (err: any) {
+        const errorMessage = err.message?.toLowerCase() || "";
         if (err.status === 403) {
-          setError('GitHub API rate limit exceeded. Please wait or use a token.');
-          setRateLimited(true); // Prevent further fetches
-        } else {
+          setError('GitHub API rate limit exceeded. Please provide a PAT to continue.');
+          setRateLimited(true); 
+        } else if (errorMessage.includes("do not exist")){
+          setError('User not found. Please check the spelling of the GitHub username.');
+        } else if (err.status === 401 || errorMessage.includes("permission")){
+          setError('Private repository detected. Please input PAT.');
+        }else if(err.status===404){
+          setError('Resource not found.');
+        }
+        else{
           setError(err.message || 'Failed to fetch data');
         }
       } finally {
         setLoading(false);
       }
     },
-    [getOctokit, rateLimited]
+    [getOctokit]
   );
 
   return {

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -180,7 +180,6 @@ const Home: React.FC = () => {
               value={token}
               onChange={(e) => setToken(e.target.value)}
               type="password"
-              required
               sx={{ flex: 1, minWidth: 150 }}
             />
             <Button type="submit" variant="contained" sx={{ minWidth: "120px" }}>


### PR DESCRIPTION
### Related Issue
- Closes: #<224>
Issue 224:Enhancement: Enable Public Repo Tracking Without Personal Access Token (PAT)
---

### Description


---Changes:
1.Optional PAT: Make the PAT input field optional in the layout.
2.Unauthenticated Fetch: When a repository URL is entered, attempt to fetch data using a standard GET request to without an authorization header.
3.Fallback/Rate Limit Handling:If the request succeeds, render the tracking data immediately.
4.If the request fails due to a 403 (Rate Limit Exceeded), then prompt the user to provide a PAT("GitHub API rate limit exceeded. Please provide a PAT to continue.")
5..If the repository is private, show a specific message: "Private repository detected. Please input PAT".
6.If username is wrong,display('User not found. Please check the spelling of the GitHub username.').

### How Has This Been Tested?

Run locally as well as in network
---

### Screenshots (if applicable)


<img width="715" height="326" alt="Screenshot 2026-05-15 010210" src="https://github.com/user-attachments/assets/1698012a-fbd1-46ab-909b-058b1946ed9a" />


#
<img width="447" height="196" alt="Screenshot 2026-05-15 010053" src="https://github.com/user-attachments/assets/60ac5cde-8324-425f-a5dd-70b3a5ba0610" />
## Type of Change

- [ ] Bug fix
- [ X] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now works with username alone; Personal Access Token is optional.

* **Bug Fixes**
  * Improved error handling with more specific messages for API failures, including rate-limit and permission issues.

* **Chores**
  * Updated icon library dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->