### PR TITLE
Enhance dashboard UX with loading skeletons and empty states

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -20,7 +20,6 @@ import {
   TableRow,
   TablePagination,
   Link,
-  CircularProgress,
   Alert,
   Tabs,
   Tab,
@@ -28,6 +27,8 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
+  Skeleton,
+  Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useGitHubAuth } from "../../hooks/useGitHubAuth";
@@ -279,11 +280,62 @@ const Home: React.FC = () => {
       )}
 
       {loading ? (
-        <Box display="flex" justifyContent="center" my={4}>
-          <CircularProgress />
-        </Box>
-      ) : (
-        <Box sx={{ maxHeight: "400px", overflowY: "auto" }}>
+  <Box sx={{ maxHeight: "400px", overflowY: "auto" }}>
+    <TableContainer component={Paper}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Title</TableCell>
+            <TableCell align="center">Repository</TableCell>
+            <TableCell align="center">State</TableCell>
+            <TableCell>Created</TableCell>
+          </TableRow>
+        </TableHead>
+
+        <TableBody>
+          {[...Array(5)].map((_, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Skeleton variant="text" width="80%" height={30} />
+              </TableCell>
+
+              <TableCell align="center">
+                <Skeleton variant="text" width="60%" height={30} />
+              </TableCell>
+
+              <TableCell align="center">
+                <Skeleton variant="rounded" width={70} height={25} />
+              </TableCell>
+
+              <TableCell>
+                <Skeleton variant="text" width="70%" height={30} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </Box>
+) : currentFilteredData.length === 0 ? (
+  <Paper
+    elevation={1}
+    sx={{
+      p: 4,
+      textAlign: "center",
+      backgroundColor: theme.palette.background.paper,
+    }}
+  >
+    <Typography variant="h6" gutterBottom>
+      No Data Found
+    </Typography>
+
+    <Typography variant="body2" color="text.secondary">
+      Try adjusting filters or searching for another GitHub user.
+    </Typography>
+  </Paper>
+) : (
+    
+  <Box sx={{ maxHeight: "400px", overflowY: "auto" }}>
 
           <TableContainer component={Paper}>
 

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -316,7 +316,7 @@ const Home: React.FC = () => {
       </Table>
     </TableContainer>
   </Box>
-) : currentFilteredData.length === 0 ? (
+) : !authError && !dataError && currentFilteredData.length === 0 ? (
   <Paper
     elevation={1}
     sx={{


### PR DESCRIPTION
### Related Issue
- Closes: #<240>

---

### Description

This PR enhances the dashboard user experience by replacing the basic loading spinner (CircularSpinner) with responsive skeleton loaders and improving empty-state handling for better visual feedback.

Changes Made:

- Added loading skeletons for dashboard tables
- Improved empty-state UI when no GitHub data is available
- Enhanced overall dashboard responsiveness and UX consistency
- Maintained compatibility across light and dark modes

---

### How Has This Been Tested?

- Tested loading skeleton rendering during API fetch
- Verified empty-State UI by using unavailable/No data
- Checked responsiveness across different screen sizes
- Confirmed proper functionality in both light and dark modes

---

### Screenshots (if applicable)
Before:
<img width="943" height="435" alt="image" src="https://github.com/user-attachments/assets/209d334f-bb04-4c50-b590-b22656764179" />

<img width="937" height="437" alt="image" src="https://github.com/user-attachments/assets/b342af31-504d-4dd0-a9e1-0195935efe83" />

After changes:
<img width="932" height="430" alt="image" src="https://github.com/user-attachments/assets/3be62226-b581-4e34-825a-fc94e17008ef" />

<img width="951" height="435" alt="image" src="https://github.com/user-attachments/assets/b7762b53-fb65-4a2f-8fcf-79fc0985bd86" />


---

### Type of Change

- [x] Enhancement
- [x] UI/UX Improvement

- [ ] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The loading state now displays a skeleton table with placeholder rows instead of a spinner, providing clearer visual feedback about the data structure being loaded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->