### PR TITLE
fix: install dev deps before build in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -7,12 +7,12 @@ WORKDIR /app
 # Copy package.json
 COPY package.json .
 
-# Install production dependencies using Yarn
-RUN npm install --production
+# Install dependencies (dev deps needed for the build step)
+RUN npm install
 # Copy the rest of the application files
 COPY . .
 
-# Build the frontend using Yarn
+# Build the frontend
 RUN npm run build
 
 # Stage 2: Serve the application with Nginx


### PR DESCRIPTION
### Related Issue
- Closes: #243

### Description
Fix the production Docker build by installing all dependencies before running `npm run build` in `Dockerfile.prod`. This ensures dev-only build tools (like Vite) are available during the build stage.

---

### How Has This Been Tested?
- Built the production image locally: `docker build -f Dockerfile.prod .`

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker production build configuration for improved build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/247)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->