### PR TITLE
Added [feature]: PAT helper link for token generation guide

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -182,7 +182,25 @@ const Home: React.FC = () => {
               type="password"
               required
               sx={{ flex: 1, minWidth: 150 }}
+              helperText={
+                <Link
+                href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+      fontSize: '0.75rem',
+      color: 'primary.main',
+      textDecoration: 'none',
+      '&:hover': {
+        textDecoration: 'underline',
+      }
+    }}
+                >
+                  How to generate?
+                </Link>
+              }
             />
+
             <Button type="submit" variant="contained" sx={{ minWidth: "120px" }}>
               Fetch Data
             </Button>

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -182,6 +182,7 @@ const Home: React.FC = () => {
               type="password"
               required
               sx={{ flex: 1, minWidth: 150 }}
+              // Helper link to guide users on generating a GitHub Personal Access Token
               helperText={
                 <Link
                 href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"


### PR DESCRIPTION
### Related Issue
- Closes: #232

---

### Description
Added a "How to generate?" helper link below the Personal Access Token field. This link opens the official GitHub PAT documentation in a new tab, guiding users who are unfamiliar with generating a Personal Access Token.

---

### How Has This Been Tested?
- Ran the frontend locally using `npm run dev`
- Verified the helper link appears below the PAT field
- Confirmed the link opens GitHub docs in a new tab
- Confirmed no errors in the console

---

### Screenshot
<img width="1351" height="675" alt="Screenshot (79)" src="https://github.com/user-attachments/assets/c8543da0-4608-4f95-9dc7-d0ead1cd9cb6" />


---

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a helper link under the Personal Access Token input field that directs users to GitHub's documentation for generating tokens, opening in a new browser tab for easy reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->