### PR TITLE
Fix duplicate ThemeProvider causing unnecessary re-renders and context conflicts (#271)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,9 @@ import Footer from "./components/Footer";
 import ScrollProgressBar from "./components/ScrollProgressBar";
 import { Toaster } from "react-hot-toast";
 import Router from "./Routes/Router";
-import ThemeWrapper from "./context/ThemeContext";
 
 function App() {
   return (
-    <ThemeWrapper>
       <div className="relative flex flex-col min-h-screen">
         <ScrollProgressBar />
 
@@ -37,7 +35,6 @@ function App() {
           }}
         />
       </div>
-    </ThemeWrapper>
   );
 }
 


### PR DESCRIPTION
## 🐛 Problem

ThemeWrapper (ThemeContext Provider) was being used in both `main.tsx` and `App.tsx`.

This resulted in duplicate context wrapping in the React component tree.

---

##   Impact

Although the UI was not breaking, this caused:

- Duplicate ThemeContext instances
- Unnecessary re-renders in components consuming theme
- Risk of inconsistent theme state behavior
- Non-optimal React architecture (violates best practices)

---

##   Solution

Removed `ThemeWrapper` from `App.tsx` and ensured it is only used once at the root level in `main.tsx`.

Now the correct structure is:

---

##   Changes Made

- Removed duplicate `ThemeWrapper` from `App.tsx`
- Maintained single ThemeProvider at root level (`main.tsx`)
- No UI changes expected

---
##  Issue No:- 

Fixes #271

##   Why this fix matters

This ensures:
- Proper React Context usage
- Better performance (no duplicate providers)
- Cleaner and scalable architecture
- Follows React best practices

---

##   Notes

This is a structural/architecture improvement. There are no visual/UI changes introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified application structure by removing an unused wrapper component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->