### PR TITLE
Add hover effects to Features section (dark & light mode)

### DIFF
--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -60,8 +60,10 @@ const Features = () => {
           {features.map((feature, index) => {
             const IconComponent = feature.icon;
             return (
-              <div key={index} className="bg-gray-50 dark:bg-gray-800 p-8 rounded-2xl hover:shadow-lg transition-all duration-300">
-                <div className={`${feature.bgColor} w-12 h-12 rounded-lg flex items-center justify-center mb-6`}>
+              <div key={index} className="bg-gray-50 dark:bg-gray-800 p-8 rounded-2xl transition-all duration-300
+  hover:-translate-y-2 hover:shadow-2xl hover:bg-blue-100 
+  dark:hover:bg-gray-600">
+                <div className={`${feature.bgColor} w-12 h-12 rounded-lg flex items-center justify-center mb-6 transition-transform duration-300`}>
                   <IconComponent className={`h-6 w-6 ${feature.iconColor}`} />
                 </div>
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">{feature.title}</h3>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -60,10 +60,8 @@ const Features = () => {
           {features.map((feature, index) => {
             const IconComponent = feature.icon;
             return (
-              <div key={index} className="bg-gray-50 dark:bg-gray-800 p-8 rounded-2xl transition-all duration-300
-  hover:-translate-y-2 hover:shadow-2xl hover:bg-blue-100 
-  dark:hover:bg-gray-600">
-                <div className={`${feature.bgColor} w-12 h-12 rounded-lg flex items-center justify-center mb-6 transition-transform duration-300`}>
+              <div key={index} className="bg-gray-50 dark:bg-gray-800 p-8 rounded-2xl transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl hover:bg-blue-100 dark:hover:bg-gray-600">
+                <div className={`${feature.bgColor} w-12 h-12 rounded-lg flex items-center justify-center mb-6 transition-transform hover:scale-110 duration-300`}>
                   <IconComponent className={`h-6 w-6 ${feature.iconColor}`} />
                 </div>
                 <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">{feature.title}</h3>


### PR DESCRIPTION
### Related Issue
- Closes: #288 

### Description
Add hover effects to the Features section cards to improve UI interactivity and user experience in both light and dark modes

### How Has This Been Tested?

- Navigate the Features section in the home page 
- Tested hover effects on feature cards in both light and dark modes 
- Verified smooth transition effects (translate, scale, shadow, and background change)

### Screenshots (if applicable)

<img width="1884" height="897" alt="Screenshot 2026-05-17 125536" src="https://github.com/user-attachments/assets/a5e982c0-9092-44e1-b2f8-11271428dead" />


### Type of Change

- [ ] Bug fix
- [✔] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Feature cards now use a consistent gray background and simplified hover visuals for a cleaner, more uniform look across light/dark modes.
  * Feature icons gain smooth scale-on-hover animations for improved interactivity.
  * Note: Card hover no longer alters feature titles or descriptions—those text elements no longer respond to hovering the card.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->