### PR TITLE
Fix misleading private repository message during partial fetch

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -36,15 +36,28 @@ export const useGitHubData = (getOctokit: () => any) => {
       setError('');
 
       try {
-        const [issueRes, prRes] = await Promise.all([
+        const [issueRes, prRes] = await Promise.allSettled([
           fetchPaginated(octokit, username, 'issue', page, perPage),
           fetchPaginated(octokit, username, 'pr', page, perPage),
         ]);
 
-        setIssues(issueRes.items);
-        setPrs(prRes.items);
-        setTotalIssues(issueRes.total);
-        setTotalPrs(prRes.total);
+        if (issueRes.status === 'fulfilled') {
+          setIssues(issueRes.value.items);
+          setTotalIssues(issueRes.value.total);
+        }
+
+        if (prRes.status === 'fulfilled') {
+          setPrs(prRes.value.items);
+          setTotalPrs(prRes.value.total);
+        }
+
+        if (
+          issueRes.status === 'rejected' ||
+          prRes.status === 'rejected'
+        ) {
+          setError('Some GitHub data could not be fetched completely.');
+        }
+
         setRateLimited(false);
       } catch (err: any) {
         const errorMessage = err.message?.toLowerCase() || "";
@@ -53,13 +66,20 @@ export const useGitHubData = (getOctokit: () => any) => {
           setRateLimited(true); 
         } else if (errorMessage.includes("do not exist")){
           setError('User not found. Please check the spelling of the GitHub username.');
-        } else if (err.status === 401 || errorMessage.includes("permission")){
+        } 
+        else if (errorMessage.includes("validation failed")) {
+          setError('Invalid GitHub username or insufficient permissions.');
+        }
+        else if (err.status === 401 || errorMessage.includes("permission")){
           setError('Private repository detected. Please input PAT.');
         }else if(err.status===404){
           setError('Resource not found.');
         }
-        else{
-          setError(err.message || 'Failed to fetch data');
+        
+        else {
+          setError(
+            'Unable to fetch GitHub data. Please verify the username, token, or network connection.'
+          );
         }
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Related Issue
Closes #300

---

## Description

This PR improves GitHub tracker error handling during partial API fetch failures.

### Changes made:
- Replaced `Promise.all()` with `Promise.allSettled()`
- Allowed partial GitHub data rendering when one request succeeds
- Prevented misleading global "Private repository detected" errors during partial fetches
- Added contextual warning messages for incomplete data fetch scenarios
- Improved overall async error handling behavior

---

## How Has This Been Tested?

- Tested with valid GitHub usernames and invalid/random PATs
- Verified pull request data still renders during partial fetch failures
- Confirmed misleading private repository message no longer appears during partial success cases

---

## Screenshots
Before
<img width="1256" height="537" alt="Screenshot 2026-05-17 201423" src="https://github.com/user-attachments/assets/0e193773-f101-4c8e-829d-91e873fbfbc4" />
After
<img width="1233" height="521" alt="Screenshot 2026-05-17 201901" src="https://github.com/user-attachments/assets/7597e4ec-5048-4aa7-8dd7-b5de37808cdd" />


Added in PR discussion.

---

## Type Of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GitHub search reliability by allowing partial results when one data source experiences issues
  * Enhanced error messages for common GitHub API failures including rate limiting and permission errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->