### PR TITLE
fix: update PAT link to redirect directly to GitHub token generation …

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -185,7 +185,7 @@ const Home: React.FC = () => {
               // Helper link to guide users on generating a GitHub Personal Access Token
               helperText={
                 <Link
-                href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens"
+                href="https://github.com/settings/tokens/new"
                 target="_blank"
                 rel="noopener noreferrer"
                 sx={{


### PR DESCRIPTION
…page

### Related Issue
- Closes: #305 

---

### Description
Updated the "How to generate?" link under the Personal Access Token input. Previously, it redirected users to a lengthy GitHub documentation page, causing UX friction for users trying to quickly bypass the 60-request unauthenticated API rate limit. This PR changes the `href` to point directly to `https://github.com/settings/tokens/new`, allowing users to instantly generate a token and seamlessly continue using the app.

---

### How Has This Been Tested?
- Ran the application locally.
- Clicked the "How to generate?" link on the Tracker page.
- Verified that it correctly opens the direct GitHub token creation page in a new tab rather than the documentation.

---

### Screenshots (if applicable)
*N/A — simple URL redirect update.*

---

### Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitHub Personal Access Token helper link in the authentication form to direct users to the correct GitHub page for token creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->