### PR TITLE
fix: replace console.log with structured JSON logger in backend/server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -30,8 +30,8 @@ app.use('/api/auth', authRoutes);
 
 /**
  * Structured logger -- gates output behind NODE_ENV so that
- * verbose logs are suppressed in production (NODE_ENV=production)
- * and tests (NODE_ENV=test) while remaining available in development.
+ * logs are suppressed in tests (NODE_ENV=test).
+ * In development and production, JSON logs are emitted.
  *
  * Each log entry is emitted as a JSON line for easy ingestion by
  * log-aggregation tools (Datadog, CloudWatch, ELK, etc.).

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,9 +17,9 @@ app.use(cors('*'));
 // Middleware
 app.use(bodyParser.json());
 app.use(session({
-    secret: process.env.SESSION_SECRET,
-    resave: false,
-    saveUninitialized: false,
+        secret: process.env.SESSION_SECRET,
+        resave: false,
+        saveUninitialized: false,
 }));
 app.use(passport.initialize());
 app.use(passport.session());
@@ -28,12 +28,45 @@ app.use(passport.session());
 const authRoutes = require('./routes/auth');
 app.use('/api/auth', authRoutes);
 
+/**
+ * Structured logger -- gates output behind NODE_ENV so that
+ * verbose logs are suppressed in production (NODE_ENV=production)
+ * and tests (NODE_ENV=test) while remaining available in development.
+ *
+ * Each log entry is emitted as a JSON line for easy ingestion by
+ * log-aggregation tools (Datadog, CloudWatch, ELK, etc.).
+ */
+const logger = {
+        _write(level, message, meta = {}) {
+                    // Suppress all logging in test environments
+            if (process.env.NODE_ENV === 'test') return;
+
+            const entry = {
+                            timestamp: new Date().toISOString(),
+                            level,
+                            message,
+                            ...meta,
+            };
+
+            if (level === 'error') {
+                            // Errors go to stderr so they can be captured separately
+                        process.stderr.write(JSON.stringify(entry) + '\n');
+            } else {
+                            // info / warn go to stdout
+                        process.stdout.write(JSON.stringify(entry) + '\n');
+            }
+        },
+        info(message, meta)  { this._write('info',  message, meta); },
+        warn(message, meta)  { this._write('warn',  message, meta); },
+        error(message, meta) { this._write('error', message, meta); },
+};
+
 // Connect to MongoDB
 mongoose.connect(process.env.MONGO_URI, {}).then(() => {
-    console.log('Connected to MongoDB');
-    app.listen(process.env.PORT, () => {
-        console.log(`Server running on port ${process.env.PORT}`);
-    });
+        logger.info('Connected to MongoDB');
+        app.listen(process.env.PORT, () => {
+                    logger.info('Server started', { port: process.env.PORT });
+        });
 }).catch((err) => {
-    console.log('MongoDB connection error:', err);
+        logger.error('MongoDB connection error', { error: err.message, stack: err.stack });
 });


### PR DESCRIPTION
## Summary

Closes #308

Replaces all three bare `console.log` / `console.error` calls in `backend/server.js` with a lightweight structured logger that emits **JSON log lines** to `stdout`/`stderr`.

## Why no new dependency?

Adding `winston` or `pino` would require updating `package.json`, `package-lock.json`, and potentially CI caching -- increasing review surface. The inline logger achieves the same structured-output goal with zero overhead and is trivially replaceable with a full logging library later.

## Changes

| Before | After |
|---|---|
| `console.log('Connected to MongoDB')` | `logger.info('Connected to MongoDB')` |
| `console.log('Server running on port ...')` | `logger.info('Server started', { port })` |
| `console.log('MongoDB connection error:', err)` | `logger.error('MongoDB connection error', { error, stack })` |

## Logger behaviour

- **`NODE_ENV=test`** -> all output suppressed (safe for unit tests)
- - **`NODE_ENV=production`** -> JSON lines emitted; `error` level goes to `stderr`
- - **`NODE_ENV=development`** -> same JSON lines, easy to pipe to `jq`
## Sample output

```json
{"timestamp":"2025-05-18T04:00:00.000Z","level":"info","message":"Connected to MongoDB"}
{"timestamp":"2025-05-18T04:00:00.001Z","level":"info","message":"Server started","port":"5000"}
```

---

**GSSoC '26 Participant:** GOUTAM KUMAR GHOSAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced ad-hoc console output with structured JSON logging for startup and runtime visibility.
  * Improved error reporting for database connection failures with richer diagnostic details.
  * Routed log levels to appropriate streams and suppressed logs during test runs for cleaner output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->