### PR TITLE
feat: add glassmorphism effect to navbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
   const isFullscreen = FULLSCREEN_ROUTES.includes(location.pathname);
 
   return (
-      <div className="relative flex flex-col min-h-screen">
+      <div className="relative bg-[#1F2937] flex flex-col min-h-screen">
         {!isFullscreen && <ScrollProgressBar />}
 
         {!isFullscreen && <Navbar />}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Link } from "react-router-dom";
 import { useState, useContext } from "react";
 import { ThemeContext } from "../context/ThemeContext";
-import { Moon, Sun, Menu, X, UserPlus } from 'lucide-react';
+import { Moon, Sun, Menu, X } from "lucide-react";
 
 const Navbar: React.FC = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -10,15 +10,8 @@ const Navbar: React.FC = () => {
   if (!themeContext) return null;
   const { toggleTheme, mode } = themeContext;
 
-  const navLinkStyles = ({ isActive }: { isActive: boolean }) => 
-    `px-5 py-2 rounded-full text-lg font-semibold transition-all duration-300 
-    ${isActive 
-      ? "text-blue-600 bg-blue-100/60 dark:bg-blue-900/40 shadow-sm ring-1 ring-blue-200/50" 
-      : "text-slate-600 dark:text-gray-300 hover:text-blue-500 hover:bg-white/50"
-    }`;
-
   return (
-    <nav className="sticky top-0 z-50 bg-white dark:bg-gray-900 text-black dark:text-white border-b border-gray-100 dark:border-gray-800 transition-colors duration-300">
+    <nav className="sticky top-0 z-50  bg-white/80 dark:bg-gray-900/80 backdrop-blur-md text-black dark:text-white border-b border-gray-100 dark:border-gray-800 transition-colors duration-300">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
         {/* Logo Section */}
         <Link
@@ -30,110 +23,121 @@ const Navbar: React.FC = () => {
         </Link>
 
         {/* Desktop Links */}
-        <div className="hidden md:flex space-x-6">
+        <div className="hidden md:flex space-x-6 items-center">
           <Link
             to="/"
             className="text-lg font-medium hover:text-gray-300 transition-all px-2 py-1 border border-transparent hover:border-gray-400 rounded"
           >
             Home
           </Link>
+
           <Link
             to="/track"
             className="text-lg font-medium hover:text-gray-300 transition-all px-2 py-1 border border-transparent hover:border-gray-400 rounded"
           >
             Tracker
           </Link>
+
           <Link
             to="/contributors"
             className="text-lg font-medium hover:text-gray-300 transition-all px-2 py-1 border border-transparent hover:border-gray-400 rounded"
           >
             Contributors
           </Link>
+
           <Link
             to="/login"
             className="text-lg font-medium hover:text-gray-300 transition-all px-2 py-1 border border-transparent hover:border-gray-400 rounded"
           >
             Login
           </Link>
+
           <button
             onClick={toggleTheme}
             className="text-sm font-semibold px-3 py-1 rounded border border-gray-500 hover:text-gray-300 hover:border-gray-300 transition duration-200"
+            aria-label="Toggle theme"
           >
-            {mode === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+            {mode === "dark" ? (
+              <Sun className="h-5 w-5" />
+            ) : (
+              <Moon className="h-5 w-5" />
+            )}
           </button>
         </div>
 
         {/* Mobile Menu Button */}
-        <div className="md:hidden">
+        <div className="md:hidden flex items-center space-x-3">
+          <button
+            onClick={toggleTheme}
+            className="p-2 text-slate-500 dark:text-gray-400"
+            aria-label="Toggle theme"
+          >
+            {mode === "dark" ? (
+              <Sun className="h-6 w-6" />
+            ) : (
+              <Moon className="h-6 w-6" />
+            )}
+          </button>
+
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="relative w-8 h-8 flex flex-col space-y-[5px] items-center group focus:outline-none"
+            className="p-2.5 rounded-2xl bg-white/80 dark:bg-gray-800 text-slate-900 dark:text-white"
+            aria-label="Toggle navigation menu"
+            aria-expanded={isOpen}
           >
-            <span
-              className={`block h-[3px] w-full bg-black dark:bg-white rounded-lg transition-transform duration-300 ${
-                isOpen ? "rotate-45 translate-y-2" : ""
-              }`}
-            ></span>
-            <span
-              className={`block h-[3px] w-full bg-black dark:bg-white rounded-lg transition-opacity duration-300 ${
-                isOpen ? "opacity-0" : ""
-              }`}
-            ></span>
-            <span
-              className={`block h-[3px] w-full bg-black dark:bg-white rounded-lg transition-transform duration-300 ${
-                isOpen ? "-rotate-45 -translate-y-2" : ""
-              }`}
-            ></span>
+            {isOpen ? (
+              <X className="h-7 w-7" />
+            ) : (
+              <Menu className="h-7 w-7" />
+            )}
           </button>
         </div>
       </div>
 
-      {/* Mobile Links */}
-      {isOpen && (
-        <div className="md:hidden bg-white dark:bg-gray-800 text-black dark:text-white">
-          <div className="space-y-4 px-6 py-4">
+      {/* Mobile Menu Panel */}
+      <div
+        className={`
+          md:hidden overflow-hidden transition-all duration-500 ease-in-out 
+          bg-indigo-50/95 dark:bg-gray-900/95 backdrop-blur-xl
+          ${
+            isOpen
+              ? "max-h-[600px] opacity-100 border-t border-indigo-100/50 dark:border-gray-800 shadow-2xl visible"
+              : "max-h-0 opacity-0 invisible"
+          }
+        `}
+      >
+        <div className="px-5 py-10 space-y-4">
+          <MobileNavLink to="/" onClick={() => setIsOpen(false)}>
+            Home
+          </MobileNavLink>
+
+          <MobileNavLink to="/track" onClick={() => setIsOpen(false)}>
+            Tracker
+          </MobileNavLink>
+
+          <MobileNavLink
+            to="/contributors"
+            onClick={() => setIsOpen(false)}
+          >
+            Contributors
+          </MobileNavLink>
+
+          <div className="pt-8 mt-6 border-t border-indigo-100/50 dark:border-gray-800 grid grid-cols-2 gap-5">
             <Link
-              to="/"
-              className="block text-lg font-medium hover:text-gray-300 transition-all px-2 py-1 border border-transparent hover:border-gray-400 rounded"
+              to="/login"
+              className="flex items-center justify-center py-4 text-lg font-bold text-slate-700 dark:text-gray-200 bg-white/60 dark:bg-gray-800/60 rounded-2xl border border-indigo-100/50 dark:border-gray-700"
               onClick={() => setIsOpen(false)}
             >
-              Home
+              Login
             </Link>
-          </div>
 
-          <div className="lg:hidden flex items-center space-x-3">
-            <button onClick={toggleTheme} className="p-2 text-slate-500 dark:text-gray-400" aria-label="Toggle theme">
-              {mode === "dark" ? <Sun className="h-6 w-6" /> : <Moon className="h-6 w-6" />}
-            </button>
-            
-            <button
-              onClick={() => setIsOpen(!isOpen)}
-              className="p-2.5 rounded-2xl bg-white/80 dark:bg-gray-800 text-slate-900 dark:text-white"
-              aria-label="Toggle navigation menu"
-              aria-expanded={isOpen}
+            <Link
+              to="/signup"
+              className="flex items-center justify-center py-4 text-lg font-bold text-white bg-blue-600 rounded-2xl shadow-lg"
+              onClick={() => setIsOpen(false)}
             >
-              {isOpen ? <X className="h-7 w-7" /> : <Menu className="h-7 w-7" />}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Mobile Menu Panel */}
-      <div className={`
-        lg:hidden overflow-hidden transition-all duration-500 ease-in-out bg-indigo-50/95 dark:bg-gray-900/95 backdrop-blur-xl
-        ${isOpen 
-          ? "max-h-[600px] opacity-100 border-t border-indigo-100/50 dark:border-gray-800 shadow-2xl visible" 
-          : "max-h-0 opacity-0 invisible"
-        }
-      `}>
-        <div className="px-5 py-10 space-y-4">
-          <MobileNavLink to="/" onClick={() => setIsOpen(false)}>Home</MobileNavLink>
-          <MobileNavLink to="/track" onClick={() => setIsOpen(false)}>Tracker</MobileNavLink>
-          <MobileNavLink to="/contributors" onClick={() => setIsOpen(false)}>Contributors</MobileNavLink>
-          
-          <div className="pt-8 mt-6 border-t border-indigo-100/50 dark:border-gray-800 grid grid-cols-2 gap-5">
-            <Link to="/login" className="flex items-center justify-center py-4 text-lg font-bold text-slate-700 dark:text-gray-200 bg-white/60 dark:bg-gray-800/60 rounded-2xl border border-indigo-100/50 dark:border-gray-700" onClick={() => setIsOpen(false)}>Login</Link>
-            <Link to="/signup" className="flex items-center justify-center py-4 text-lg font-bold text-white bg-blue-600 rounded-2xl shadow-lg" onClick={() => setIsOpen(false)}>Sign Up</Link>
+              Sign Up
+            </Link>
           </div>
         </div>
       </div>
@@ -141,8 +145,28 @@ const Navbar: React.FC = () => {
   );
 };
 
-const MobileNavLink = ({ to, children, onClick }: { to: string, children: React.ReactNode, onClick: () => void }) => (
-  <NavLink to={to} onClick={onClick} className={({ isActive }) => `block px-6 py-4 rounded-2xl text-xl font-bold transition-all ${isActive ? "bg-blue-600 text-white shadow-lg translate-x-2" : "text-slate-600 dark:text-gray-400 hover:bg-white/40 dark:hover:bg-gray-800/40"}`}>{children}</NavLink>
+const MobileNavLink = ({
+  to,
+  children,
+  onClick,
+}: {
+  to: string;
+  children: React.ReactNode;
+  onClick: () => void;
+}) => (
+  <NavLink
+    to={to}
+    onClick={onClick}
+    className={({ isActive }) =>
+      `block px-6 py-4 rounded-2xl text-xl font-bold transition-all ${
+        isActive
+          ? "bg-blue-600 text-white shadow-lg translate-x-2"
+          : "text-slate-600 dark:text-gray-400 hover:bg-white/40 dark:hover:bg-gray-800/40"
+      }`
+    }
+  >
+    {children}
+  </NavLink>
 );
 
 export default Navbar;


### PR DESCRIPTION
### Related Issue

* Closes: #330

---

### Description

This PR enhances the navbar UI by introducing a modern **glassmorphism effect** while preserving existing functionality and responsiveness.

#### Changes Made

* Added subtle background transparency to the navbar
* Added backdrop blur effect for a glass-like appearance
* Added soft border separation for improved visual layering
* Ensured proper readability in both light and dark themes
* Maintained responsiveness without layout shifts

#### Why This Change?

* Improves modern UI aesthetics
* Enhances visual depth and consistency
* Aligns the navbar with current application design trends
* Improves user experience without changing functionality

---

### How Has This Been Tested?

✅ Tested locally using `npm run dev`

Verified:

* Navbar renders correctly on desktop and mobile devices
* Glass effect works properly in both:

  * ☀️ Light Mode
  * 🌙 Dark Mode
* Text and icons remain readable
* No responsiveness or layout issues introduced
* Existing navbar functionality remains unchanged

---

### Screenshots (if applicable)

#### Before

<img width="1536" height="698" alt="Screenshot 2026-05-15 164331" src="https://github.com/user-attachments/assets/d7fe27f9-5b1d-4d47-a7de-5e35064dca6f" />

#### After

<img width="1536" height="692" alt="Screenshot 2026-05-19 132633" src="https://github.com/user-attachments/assets/21d2ab6f-36af-4048-b290-6ec16d5c667b" />
---

### Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied fixed background color to the application container
  * Updated navigation bar styling and layout for desktop and mobile views
  * Refined mobile menu panel structure and appearance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->