### PR TITLE
fix(auth): sanitize login response to exclude password hash

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -31,4 +31,12 @@ UserSchema.methods.comparePassword = async function (enteredPassword) {
   return bcrypt.compare(enteredPassword, this.password);
 };
 
+UserSchema.methods.toSafeObject = function () {
+  return {
+    id: this._id,
+    username: this.username,
+    email: this.email,
+  };
+};
+
 module.exports = mongoose.model("User", UserSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -32,7 +32,7 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
 
 // Login route
 router.post("/login", validateRequest(loginSchema), passport.authenticate('local'), (req, res) => {
-    + res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
+    res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
 });
 
 // Logout route

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -32,7 +32,7 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
 
 // Login route
 router.post("/login", validateRequest(loginSchema), passport.authenticate('local'), (req, res) => {
-    res.status(200).json( { message: 'Login successful', user: req.user } );
+    + res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
 });
 
 // Logout route


### PR DESCRIPTION
### Related Issue
- Closes: #364 

---

### Description

Added toSafeObject() method on User model that returns only id,
username, and email. Use it in the /api/auth/login route instead
of sending the raw Mongoose user object which included the
bcrypt-hashed password field.

---

### How Has This Been Tested?

Tested with 

```
curl -X POST http://localhost:<PORT>/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"Test1234"}'
```
---

### Screenshots (if applicable)


---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login endpoint to return sanitized user data without exposing sensitive fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->