### PR TITLE
feat: add password visibility toggle to login form

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -124,11 +124,13 @@ const Login: React.FC = () => {
     }`}
   />
 
-  <button
-    type="button"
-    onClick={() => setShowPassword(!showPassword)}
-    className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500"
-  >
+ <button
+  type="button"
+  onClick={() => setShowPassword(!showPassword)}
+  aria-label={showPassword ? "Hide password" : "Show password"}
+  aria-pressed={showPassword}
+  className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500"
+>
     {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
   </button>
 </div>

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState, ChangeEvent, FormEvent, useContext } from "react";
 import axios from "axios";
 import { useNavigate, Link } from "react-router-dom";
 import { ThemeContext } from "../../context/ThemeContext";
+import { Eye, EyeOff } from "lucide-react";
 import type { ThemeContextType } from "../../context/ThemeContext";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
@@ -15,6 +16,7 @@ const Login: React.FC = () => {
   const [formData, setFormData] = useState<LoginFormData>({ email: "", password: "" });
   const [message, setMessage] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const navigate = useNavigate();
   const themeContext = useContext(ThemeContext) as ThemeContextType;
@@ -106,22 +108,30 @@ const Login: React.FC = () => {
               />
             </div>
 
-            <div className="relative">
-              <input
-                type="password"
-                name="password"
-                autoComplete="current-password"
-                placeholder="Enter your password"
-                value={formData.password}
-                onChange={handleChange}
-                required
-                className={`w-full pl-4 pr-4 py-4 rounded-2xl focus:outline-none transition-all ${
-                  mode === "dark"
-                    ? "bg-white/5 border border-white/10 text-white placeholder-slate-400 focus:ring-2 focus:ring-purple-500"
-                    : "bg-gray-100 border border-gray-300 text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-purple-400"
-                }`}
-              />
-            </div>
+           <div className="relative">
+  <input
+    type={showPassword ? "text" : "password"}
+    name="password"
+    autoComplete="current-password"
+    placeholder="Enter your password"
+    value={formData.password}
+    onChange={handleChange}
+    required
+    className={`w-full pl-4 pr-12 py-4 rounded-2xl focus:outline-none transition-all ${
+      mode === "dark"
+        ? "bg-white/5 border border-white/10 text-white placeholder-slate-400 focus:ring-2 focus:ring-purple-500"
+        : "bg-gray-100 border border-gray-300 text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-purple-400"
+    }`}
+  />
+
+  <button
+    type="button"
+    onClick={() => setShowPassword(!showPassword)}
+    className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500"
+  >
+    {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+  </button>
+</div>
 
             <button
               type="submit"


### PR DESCRIPTION
## Description
Added a password visibility toggle (eye icon) to the Login form for better usability and consistency with the Sign Up page.

<img width="2011" height="1249" alt="image" src="https://github.com/user-attachments/assets/8e49422d-da1b-4915-a4cb-e5f51a1a381f" />


## Changes Made
- Added Eye and EyeOff icons using lucide-react
- Added show/hide password functionality
- Improved user experience
- Maintained consistency between Login and Sign Up pages

Fixes #361 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a password visibility toggle button on the login page. Users can now show or hide their entered password with a click.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->