### PR TITLE
Fix session fixation vulnerability and password hash exposure in login

### DIFF
--- a/backend/config/passportConfig.js
+++ b/backend/config/passportConfig.js
@@ -9,12 +9,13 @@ passport.use(
             try {
                 const user = await User.findOne( {email} );
                 if (!user) {
-                    return done(null, false, { message: 'Email is invalid '});
+                    // Generic message prevents user enumeration
+                    return done(null, false, { message: 'Invalid credentials' });
                 }
 
                 const isMatch = await user.comparePassword(password);
                 if (!isMatch) {
-                    return done(null, false, { message: 'Invalid password' });
+                    return done(null, false, { message: 'Invalid credentials' });
                 }
 
                 return done(null, {
@@ -34,10 +35,10 @@ passport.serializeUser((user, done) => {
     done(null, user.id);
 });
 
-// Deserialize user (retrieve user from session)
+// Deserialize user — exclude password hash from req.user on every request
 passport.deserializeUser(async (id, done) => {
     try {
-        const user = await User.findById(id);
+        const user = await User.findById(id).select('-password');
         done(null, user);
     } catch (err) {
         done(err, null);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -26,13 +26,29 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
             return res.status(400).json({ message: 'User already exists' });
         }
 
-        res.status(500).json({ message: 'Error creating user', error: err.message });
+        res.status(500).json({ message: 'Error creating user' });
     }
 });
 
-// Login route
-router.post("/login", validateRequest(loginSchema), passport.authenticate('local'), (req, res) => {
-    res.status(200).json( { message: 'Login successful', user: req.user } );
+// Login route — session is regenerated after successful authentication
+// to prevent session fixation; only safe fields returned in the response
+router.post("/login", validateRequest(loginSchema), (req, res, next) => {
+    passport.authenticate('local', (err, user, info) => {
+        if (err) return next(err);
+        if (!user) return res.status(401).json({ message: info?.message || 'Invalid credentials' });
+
+        req.session.regenerate((regenerateErr) => {
+            if (regenerateErr) return next(regenerateErr);
+
+            req.logIn(user, (loginErr) => {
+                if (loginErr) return next(loginErr);
+                res.status(200).json({
+                    message: 'Login successful',
+                    user: { id: user.id, username: user.username, email: user.email },
+                });
+            });
+        });
+    })(req, res, next);
 });
 
 // Logout route
@@ -41,7 +57,7 @@ router.get("/logout", (req, res) => {
     req.logout((err) => {
 
         if (err)
-            return res.status(500).json({ message: 'Logout failed', error: err.message });
+            return res.status(500).json({ message: 'Logout failed' });
         else
             res.status(200).json({ message: 'Logged out successfully' });
     });


### PR DESCRIPTION
## What is the problem

Two vulnerabilities compound in the authentication flow:

**Session fixation:** `passport.authenticate('local')` was used as direct middleware, which stores the authenticated user into the *existing* pre-login session ID without regenerating it. An attacker who can plant a known session ID in the victim's browser (via subdomain cookie injection or briefly shared access) becomes fully authenticated as that victim after the victim logs in — no password required.

**Password hash in login response:** `deserializeUser` called `User.findById(id)` with no field projection, loading the full Mongoose document including the bcrypt-hashed password into `req.user`. The login route then returned `user: req.user` directly, sending the hash over the wire to every client that logs in. This hash can be cracked offline with a dictionary.

A third issue fixed in the same pass: distinct error messages (`'Email is invalid'` vs `'Invalid password'`) in the Passport strategy allowed an attacker to enumerate which email addresses are registered.

## What was changed

**`backend/routes/auth.js`**
- Refactored login from `passport.authenticate('local')` as middleware to the callback form, enabling explicit error handling and flow control.
- Calls `req.session.regenerate()` before `req.logIn()` so the server issues a new session ID on every successful login, destroying the pre-login session server-side.
- Returns only `{ id, username, email }` in the response body — never `req.user` which contains the full document.
- Removed `error: err.message` from the signup and logout 500 responses to prevent leaking internal server details.

**`backend/config/passportConfig.js`**
- Added `.select('-password')` to the `User.findById()` call in `deserializeUser` so the password hash is never loaded into memory on any authenticated request.
- Replaced `'Email is invalid'` and `'Invalid password'` with a single generic `'Invalid credentials'` message to close the user-enumeration vector.

## Why this approach

Session regeneration must happen *before* `req.logIn()`, not after. After `regenerate()` the old session is destroyed server-side and `req.session` points to a new empty session object; `logIn()` then writes the user ID into that new session. Reversing the order would leave a window where the old session holds the authenticated state. The callback form of `passport.authenticate` is required because middleware form gives no hook between authentication success and the response, making it impossible to call `regenerate()` in the correct position.

Using `.select('-password')` at the database layer (rather than deleting from the returned object) ensures the hash is never allocated in memory at all and cannot leak through any future code path that reads `req.user`.

## How to test

1. Make any unauthenticated request (e.g., `GET /api/auth/logout`) and record the `connect.sid` cookie value from the response.
2. `POST /api/auth/login` with valid credentials. Observe the `Set-Cookie` header — `connect.sid` must be a **different value** from step 1.
3. Inspect the JSON response body — it must contain exactly `{ "message": "Login successful", "user": { "id": "...", "username": "...", "email": "..." } }` with no `password` field at any level.
4. `POST /api/auth/login` with a registered email and wrong password, then with an unregistered email. Both must return `{ "message": "Invalid credentials" }` with status 401 — identical responses.

## Edge cases covered

- `regenerateErr` and `loginErr` are both forwarded to `next()` so they surface as 500 responses rather than silent hangs or unhandled promise rejections.
- `info?.message` uses optional chaining so a missing info object from Passport does not throw.
- `.select('-password')` is applied at query level, not as a post-processing delete, so the hash cannot be exposed by any future spread or serialisation of `req.user`.

## Verification

- [x] Root cause fully resolved
- [x] All edge cases handled
- [x] No regressions introduced — login, logout, and signup routes continue to work; existing test assertions for status codes and response shape still pass
- [x] Code matches project style and conventions

**Labels:** `type:security` `level:advanced` `gssoc:approved`

Closes #375

Please assign this PR to me under GSSoC 2026.