### PR TITLE
fix: validate env on startup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+#SESSION_SECRET=your_secret_here
+MONGO_URI=mongodb://localhost:27017/github_tracker
+PORT=5000

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -31,4 +31,12 @@ UserSchema.methods.comparePassword = async function (enteredPassword) {
   return bcrypt.compare(enteredPassword, this.password);
 };
 
+UserSchema.methods.toSafeObject = function () {
+  return {
+    id: this._id,
+    username: this.username,
+    email: this.email,
+  };
+};
+
 module.exports = mongoose.model("User", UserSchema);

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -32,7 +32,7 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
 
 // Login route
 router.post("/login", validateRequest(loginSchema), passport.authenticate('local'), (req, res) => {
-    + res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
+    res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
 });
 
 // Logout route

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -32,7 +32,7 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
 
 // Login route
 router.post("/login", validateRequest(loginSchema), passport.authenticate('local'), (req, res) => {
-    res.status(200).json( { message: 'Login successful', user: req.user } );
+    + res.status(200).json({ message: 'Login successful', user: req.user.toSafeObject() });
 });
 
 // Logout route

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,15 @@ const app = express();
 // CORS configuration
 app.use(cors('*'));
 
+const REQUIRED_ENV = ['SESSION_SECRET', 'MONGO_URI'];
+
+for (const key of REQUIRED_ENV) {
+  if (!process.env[key]) {
+    console.error(`[startup] Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
 // Middleware
 app.use(bodyParser.json());
 app.use(session({


### PR DESCRIPTION
### Related Issue
- Closes: #366 

---

### Description
If SESSION_SECRET is not set in .env, express-session silently uses
`undefined` as the secret, making all session cookies insecure.


Added a startup check that loops over required env vars and calls
`process.exit(1)` with a descriptive error if any are missing.


- `backend/server.js` — env validation block before middleware setup
- `backend/.env.example` — new file listing required variables

---

### How Has This Been Tested?
Tested by removing SESSION_SECRET from .env and confirming the
server exits with the expected error message.

---

### Screenshots (if applicable)


---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration is now validated at startup to ensure all required settings are present, preventing the application from launching with incomplete setup.
  * User authentication responses now return only essential, non-sensitive account information instead of complete user records.

* **Chores**
  * Added an example configuration template to guide local development setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->