### PR TITLE
Fix footer placeholder links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,6 +34,7 @@ function Footer() {
       "
     >
       <div className="max-w-7xl mx-auto px-8 pt-16 pb-10 relative z-10">
+
         {/* Upper Section */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-10 pb-12 border-b border-zinc-200 dark:border-zinc-800/60">
 
@@ -146,6 +147,7 @@ function Footer() {
           {/* Social Icons */}
           <div className="flex items-center space-x-5">
 
+            {/* GitHub */}
             <a
               href="https://github.com/GitMetricsLab/github_tracker"
               target="_blank"
@@ -156,21 +158,21 @@ function Footer() {
               <FaGithub className="h-6 w-6" />
             </a>
 
+            {/* Twitter */}
             <a
-              href="https://x.com/your_handle"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-zinc-600 dark:text-zinc-400 hover:text-sky-500 dark:hover:text-zinc-100 transition-all duration-300 hover:-translate-y-1 hover:scale-110"
+              href="#"
+              onClick={(e) => e.preventDefault()}
+              className="text-zinc-600 dark:text-zinc-400 hover:text-sky-500 dark:hover:text-zinc-100 transition-all duration-300 hover:-translate-y-1 hover:scale-110 opacity-70 cursor-not-allowed"
               aria-label="Twitter"
             >
               <FaTwitter className="h-6 w-6" />
             </a>
 
+            {/* Discord */}
             <a
-              href="https://discord.gg/your_invite"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-zinc-600 dark:text-zinc-400 hover:text-indigo-500 dark:hover:text-zinc-100 transition-all duration-300 hover:-translate-y-1 hover:scale-110"
+              href="#"
+              onClick={(e) => e.preventDefault()}
+              className="text-zinc-600 dark:text-zinc-400 hover:text-indigo-500 dark:hover:text-zinc-100 transition-all duration-300 hover:-translate-y-1 hover:scale-110 opacity-70 cursor-not-allowed"
               aria-label="Discord"
             >
               <FaDiscord className="h-6 w-6" />


### PR DESCRIPTION
### Related Issue

* Closes: #<your-issue-number>

---

### Description

This PR removes placeholder social media links from the footer section to prevent invalid or misleading redirects.

### Changes Made

* Removed placeholder Twitter/X redirect (`your_handle`)
* Removed placeholder Discord invite redirect (`your_invite`)
* Disabled inactive social links to avoid unintended navigation
* Maintained consistent footer UI styling and hover effects

---

### How Has This Been Tested?

* Tested locally using `npm run dev`
* Verified GitHub link still redirects correctly
* Confirmed Twitter and Discord icons no longer navigate to placeholder pages
* Checked that footer layout and styling remain intact

---

### Screenshots (if applicable)

(Add screenshots here)

---

### Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Code style update
* [ ] Breaking change
* [ ] Documentation update
