### PR TITLE
feat: Add Reset Filters and Clear Persisted Session Actions in Tracker Dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "GitHub Tracker",
+  "name": "github-tracker",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { NavLink, Link } from "react-router-dom";
 import { useState, useContext } from "react";
 import { ThemeContext } from "../context/ThemeContext";
-import { Moon, Sun, Menu, X, Github } from "lucide-react";
+import { Moon, Sun, Menu, X } from "lucide-react";
 
 const Navbar: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/__test__/Navbar.test.tsx
+++ b/src/components/__test__/Navbar.test.tsx
@@ -1,6 +1,6 @@
 // src/components/__tests__/Navbar.test.tsx
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeContext } from "../../context/ThemeContext";
 import Navbar from '../Navbar.tsx'
@@ -51,31 +51,30 @@ describe('Navbar', () => {
   // --- Mobile menu ---
   it('mobile menu is hidden by default', () => {
     renderNavbar()
-    expect(screen.queryByText('About')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /^tracker$/i })).toHaveLength(1)
   })
 
   it('opens mobile menu when hamburger is clicked', () => {
     renderNavbar()
-    const hamburger = screen.getAllByRole('button')[1] // second button = hamburger
+    const hamburger = screen.getAllByRole('button')[2] // third button = hamburger
     fireEvent.click(hamburger)
-    expect(screen.getByText('About')).toBeInTheDocument()
-    expect(screen.getByText('Contact')).toBeInTheDocument()
+    expect(screen.getAllByRole('link', { name: /^tracker$/i })).toHaveLength(2)
   })
 
   it('closes mobile menu when a nav link is clicked', () => {
     renderNavbar()
-    const hamburger = screen.getAllByRole('button')[1]
+    const hamburger = screen.getAllByRole('button')[2]
     fireEvent.click(hamburger)                          // open
+    expect(screen.getAllByRole('link', { name: /^tracker$/i })).toHaveLength(2)
     const homeLinks = screen.getAllByRole('link', { name: /home/i })
     fireEvent.click(homeLinks[homeLinks.length - 1]) // click the mobile one
-    expect(screen.queryByText('About')).not.toBeInTheDocument()  // closed
+    expect(screen.getAllByRole('link', { name: /^tracker$/i })).toHaveLength(1)  // closed
   })
 
-  it('calls toggleTheme from the mobile menu button', () => {
+  it('calls toggleTheme from the mobile theme button', () => {
     const { toggleTheme } = renderNavbar('dark')
-    const hamburger = screen.getAllByRole('button')[1]
-    fireEvent.click(hamburger)
-    fireEvent.click(screen.getByText(/light/i))
+    const mobileThemeBtn = screen.getAllByRole('button')[1] // second button = mobile theme toggle
+    fireEvent.click(mobileThemeBtn)
     expect(toggleTheme).toHaveBeenCalledTimes(1)
   })
 

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -1,9 +1,10 @@
-import { useState, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { Octokit } from '@octokit/core';
 
 export const useGitHubAuth = () => {
-  const [username, setUsername] = useState('');
-  const [token, setToken] = useState('');
+  const [username, setUsername] = useState(() => sessionStorage.getItem('tracker_username') || '');
+  const [token, setToken] = useState(() => sessionStorage.getItem('tracker_token') || '');
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (username) {
@@ -18,7 +19,19 @@ export const useGitHubAuth = () => {
     }
   }, [username, token]);
 
-  const getOctokit = () => octokit;
+  const getOctokit = () => {
+    try {
+      setError('');
+      if (!username) return null;
+      if (token) {
+        return new Octokit({ auth: token });
+      }
+      return new Octokit();
+    } catch (err: any) {
+      setError(err instanceof Error ? err.message : String(err));
+      return null;
+    }
+  };
 
   const logout = () => {
     setUsername('');
@@ -33,6 +46,8 @@ export const useGitHubAuth = () => {
     setUsername,
     token,
     setToken,
+    error,
+    setError,
     getOctokit,
     logout,
   };

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -25,6 +25,14 @@ export const useGitHubAuth = () => {
     }
   };
 
+  const logout = () => {
+    setUsername('');
+    setToken('');
+    setError('');
+    sessionStorage.removeItem('tracker_username');
+    sessionStorage.removeItem('tracker_token');
+  };
+
   return {
     username,
     setUsername,
@@ -33,5 +41,6 @@ export const useGitHubAuth = () => {
     error,
     setError,
     getOctokit,
+    logout,
   };
 };

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -7,8 +7,16 @@ export const useGitHubAuth = () => {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    sessionStorage.setItem('tracker_username', username);
-    sessionStorage.setItem('tracker_token', token);
+    if (username) {
+      sessionStorage.setItem('tracker_username', username);
+    } else {
+      sessionStorage.removeItem('tracker_username');
+    }
+    if (token) {
+      sessionStorage.setItem('tracker_token', token);
+    } else {
+      sessionStorage.removeItem('tracker_token');
+    }
   }, [username, token]);
 
   const getOctokit = () => {

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -239,6 +239,14 @@ export const useGitHubData = (
     [getOctokit, rateLimited]
   );
 
+  const clearData = useCallback(() => {
+    setIssues([]);
+    setPrs([]);
+    setTotalIssues(0);
+    setTotalPrs(0);
+    setError('');
+  }, []);
+
   return {
     issues,
     prs,
@@ -248,5 +256,6 @@ export const useGitHubData = (
     error,
     rateLimited,
     fetchData,
+    clearData,
   };
 };

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -240,11 +240,13 @@ export const useGitHubData = (
   );
 
   const clearData = useCallback(() => {
+    lastRequestId.current++;
     setIssues([]);
     setPrs([]);
     setTotalIssues(0);
     setTotalPrs(0);
     setError('');
+    setRateLimited(false);
   }, []);
 
   return {

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -241,6 +241,7 @@ export const useGitHubData = (
 
   const clearData = useCallback(() => {
     lastRequestId.current++;
+    setLoading(false);
     setIssues([]);
     setPrs([]);
     setTotalIssues(0);

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -57,6 +57,7 @@ const Home: React.FC = () => {
     setToken,
     error: authError,
     getOctokit,
+    logout,
   } = useGitHubAuth();
 
   const {
@@ -67,6 +68,7 @@ const Home: React.FC = () => {
     loading,
     error: dataError,
     fetchData,
+    clearData,
   } = useGitHubData(getOctokit);
 
   const [tab, setTab] = useState(() => Number(localStorage.getItem('tracker_tab')) || 0);
@@ -89,6 +91,32 @@ const Home: React.FC = () => {
     localStorage.setItem('tracker_startDate', startDate);
     localStorage.setItem('tracker_endDate', endDate);
   }, [tab, page, issueFilter, prFilter, searchTitle, selectedRepo, startDate, endDate]);
+
+  const handleResetFilters = () => {
+    setTab(0);
+    setPage(0);
+    setIssueFilter("all");
+    setPrFilter("all");
+    setSearchTitle("");
+    setSelectedRepo("");
+    setStartDate("");
+    setEndDate("");
+
+    localStorage.removeItem('tracker_tab');
+    localStorage.removeItem('tracker_page');
+    localStorage.removeItem('tracker_issueFilter');
+    localStorage.removeItem('tracker_prFilter');
+    localStorage.removeItem('tracker_searchTitle');
+    localStorage.removeItem('tracker_selectedRepo');
+    localStorage.removeItem('tracker_startDate');
+    localStorage.removeItem('tracker_endDate');
+  };
+
+  const handleLogout = () => {
+    logout();
+    clearData();
+    handleResetFilters();
+  };
 
   // Fetch data when username, tab, or page changes
   useEffect(() => {
@@ -249,6 +277,21 @@ const Home: React.FC = () => {
             >
                 Fetch Data
             </Button>
+            {(username || token) && (
+              <Button
+                  type="button"
+                  variant="outlined"
+                  color="error"
+                  onClick={handleLogout}
+                  sx={{
+                      minWidth: "100px",
+                      minHeight: "55px",
+                      alignSelf: "flex-start",
+                  }}
+              >
+                  Logout
+              </Button>
+            )}
           </Box>
         </form>
       </Paper>
@@ -283,6 +326,18 @@ const Home: React.FC = () => {
           InputLabelProps={{ shrink: true }}
           sx={{ minWidth: 150 }}
         />
+        {(tab !== 0 || page !== 0 || issueFilter !== "all" || prFilter !== "all" || searchTitle !== "" || selectedRepo !== "" || startDate !== "" || endDate !== "") && (
+          <Button
+              variant="outlined"
+              onClick={handleResetFilters}
+              sx={{
+                  minHeight: "56px",
+                  alignSelf: "flex-start",
+              }}
+          >
+              Reset Filters
+          </Button>
+        )}
       </Box>
 
       {/* Tabs + State Filter */}


### PR DESCRIPTION
### Description
This PR resolves issue #397 by introducing dedicated UI actions to reset active filters and clear persisted authentication sessions in the Tracker dashboard.

### Changes Made
- **`src/hooks/useGitHubAuth.ts`**: Added a `logout` function to clear credentials from `sessionStorage` and reset local authentication states.
- **`src/hooks/useGitHubData.ts`**: Added a `clearData` function to clear issues, pull requests, stats, and data error states from the dashboard's view.
- **`src/pages/Tracker/Tracker.tsx`**:
  - Implemented `handleResetFilters` to restore all filter inputs to default values and remove active filter settings from `localStorage`.
  - Implemented `handleLogout` which triggers session logout, resets fetched issues/PRs, and clears active filters in one action.
  - Added a **Logout** button next to the "Fetch Data" button inside the authentication form (rendered only when session data exists).
  - Added a **Reset Filters** button inside the filters row (rendered only when non-default filters are active).

### Checklist
- [x] Tested the changes locally
- [x] Verified that "Logout" clears credentials and resets dashboard state
- [x] Verified that "Reset Filters" removes all filters from storage and resets the UI
- [x] Verified that the application builds successfully without TypeScript or compile errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout button to clear authentication credentials and reset session data.
  * Added reset filters button to clear search parameters, date ranges, and view state.

* **Chores**
  * Updated package naming configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->