### PR TITLE
fix: add id/name attributes and labels to form fields for accessibili…

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -93,24 +93,29 @@ function Footer() {
               onSubmit={handleSubscribe}
               className="flex flex-col sm:flex-row items-stretch gap-2"
             >
-              <input
-                type="email"
-                required
-                placeholder="Enter email address"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="
-                  flex-grow text-sm px-4 py-3
-                  bg-zinc-50 dark:bg-zinc-800/40
-                  border border-zinc-200 dark:border-zinc-700/50
-                  rounded-xl
-                  focus:outline-none focus:ring-2
-                  focus:ring-blue-500/20 focus:border-blue-500
-                  text-zinc-900 dark:text-white
-                  placeholder-zinc-400 dark:placeholder-zinc-500
-                  transition-all
-                "
-              />
+              <div className="relative flex-grow">
+                <label htmlFor="newsletter-email" className="sr-only">Email address</label>
+                <input
+                  id="newsletter-email"
+                  type="email"
+                  name="email"
+                  required
+                  placeholder="Enter email address"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="
+                    w-full text-sm px-4 py-3
+                    bg-zinc-50 dark:bg-zinc-800/40
+                    border border-zinc-200 dark:border-zinc-700/50
+                    rounded-xl
+                    focus:outline-none focus:ring-2
+                    focus:ring-blue-500/20 focus:border-blue-500
+                    text-zinc-900 dark:text-white
+                    placeholder-zinc-400 dark:placeholder-zinc-500
+                    transition-all
+                  "
+                />
+              </div>
 
               <button
                 type="submit"

--- a/src/pages/Contact/Contact.tsx
+++ b/src/pages/Contact/Contact.tsx
@@ -208,6 +208,7 @@ function Contact() {
                 {/* Full Name */}
                 <div>
                   <label
+                    htmlFor="fullname"
                     className={`block text-xs font-medium mb-1 ${
                       mode === "dark"
                         ? "text-gray-300"
@@ -217,6 +218,8 @@ function Contact() {
                     Full Name
                   </label>
                   <input
+                    id="fullname"
+                    name="fullname"
                     type="text"
                     placeholder="Enter your full name"
                     required
@@ -231,6 +234,7 @@ function Contact() {
                 {/* Email */}
                 <div>
                   <label
+                    htmlFor="email"
                     className={`block text-xs font-medium mb-1 ${
                       mode === "dark"
                         ? "text-gray-300"
@@ -240,6 +244,8 @@ function Contact() {
                     Email Address
                   </label>
                   <input
+                    id="email"
+                    name="email"
                     type="email"
                     placeholder="your.email@example.com"
                     required
@@ -254,6 +260,7 @@ function Contact() {
                 {/* Subject */}
                 <div>
                   <label
+                    htmlFor="subject"
                     className={`block text-xs font-medium mb-1 ${
                       mode === "dark"
                         ? "text-gray-300"
@@ -263,6 +270,8 @@ function Contact() {
                     Subject
                   </label>
                   <select
+                    id="subject"
+                    name="subject"
                     className={`w-full p-2 sm:p-3 rounded-lg sm:rounded-xl text-sm sm:text-base transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500 ${
                       mode === "dark"
                         ? "bg-white/5 border border-white/20 text-white placeholder-gray-400"
@@ -284,6 +293,7 @@ function Contact() {
                 {/* Message */}
                 <div className="relative">
                   <label
+                    htmlFor="message"
                     className={`block text-xs font-medium mb-1 ${
                       mode === "dark"
                         ? "text-gray-300"
@@ -293,6 +303,8 @@ function Contact() {
                     Message
                   </label>
                   <textarea
+                    id="message"
+                    name="message"
                     placeholder="Type your message here..."
                     required
                     rows={4}

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -90,7 +90,9 @@ const Login: React.FC = () => {
 
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="relative">
+              <label htmlFor="email" className="sr-only">Email address</label>
               <input
+                id="email"
                 type="email"
                 name="email"
                 placeholder="Enter your email"
@@ -107,7 +109,9 @@ const Login: React.FC = () => {
             </div>
 
             <div className="relative">
+              <label htmlFor="password" className="sr-only">Password</label>
               <input
+                id="password"
                 type="password"
                 name="password"
                 autoComplete="current-password"

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -166,10 +166,18 @@ const SignUp: React.FC = () => {
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <div className="relative">
+                <label htmlFor="username" className="sr-only">Username</label>
                 <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
                   <User className="h-5 w-5 text-gray-400" />
                 </div>
-                <input type="text" name="username" placeholder="Enter your username" value={formData.username} onChange={handleChange} required
+                <input 
+                  id="username"
+                  type="text" 
+                  name="username" 
+                  placeholder="Enter your username" 
+                  value={formData.username} 
+                  onChange={handleChange} 
+                  required
                   className={`w-full pl-12 pr-4 py-4 rounded-2xl border focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent transition-all duration-300 ${mode === "dark" ? "bg-white/10 border-white/20 text-white placeholder-gray-400" : "bg-gray-100 border-gray-300 text-black placeholder-gray-400"}`}
                 />
               </div>
@@ -178,10 +186,18 @@ const SignUp: React.FC = () => {
 
             <div>
               <div className="relative">
+                <label htmlFor="email" className="sr-only">Email</label>
                 <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
                   <Mail className="h-5 w-5 text-gray-400" />
                 </div>
-                <input type="email" name="email" placeholder="Enter your email" value={formData.email} onChange={handleChange} required
+                <input 
+                  id="email"
+                  type="email" 
+                  name="email" 
+                  placeholder="Enter your email" 
+                  value={formData.email} 
+                  onChange={handleChange} 
+                  required
                   className={`w-full pl-12 pr-4 py-4 rounded-2xl border focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent transition-all duration-300 ${mode === "dark" ? "bg-white/10 border-white/20 text-white placeholder-gray-400" : "bg-gray-100 border-gray-300 text-black placeholder-gray-400"}`}
                 />
               </div>
@@ -190,13 +206,25 @@ const SignUp: React.FC = () => {
 
             <div>
               <div className="relative">
+                <label htmlFor="password" className="sr-only">Password</label>
                 <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
                   <Lock className="h-5 w-5 text-gray-400" />
                 </div>
-                <input type={showPassword ? "text" : "password"} name="password" placeholder="Enter your password" value={formData.password} onChange={handleChange} required
+                <input 
+                  id="password"
+                  type={showPassword ? "text" : "password"} 
+                  name="password" 
+                  placeholder="Enter your password" 
+                  value={formData.password} 
+                  onChange={handleChange} 
+                  required
                   className={`w-full pl-12 pr-12 py-4 rounded-2xl border focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent transition-all duration-300 ${mode === "dark" ? "bg-white/10 border-white/20 text-white placeholder-gray-400" : "bg-gray-100 border-gray-300 text-black placeholder-gray-400"}`}
                 />
-                <button type="button" onClick={() => setShowPassword(!showPassword)} aria-label={showPassword ? "Hide password" : "Show password"} aria-pressed={showPassword}
+                <button 
+                  type="button" 
+                  onClick={() => setShowPassword(!showPassword)} 
+                  aria-label={showPassword ? "Hide password" : "Show password"} 
+                  aria-pressed={showPassword}
                   className={`absolute inset-y-0 right-0 pr-4 flex items-center transition-colors duration-200 ${mode === "dark" ? "text-slate-400 hover:text-white" : "text-gray-500 hover:text-gray-800"}`}>
                   {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
                 </button>

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -299,6 +299,9 @@ const Home: React.FC = () => {
         <FormControl sx={{ minWidth: 150 }}>
           <InputLabel sx={{ fontSize: "14px" }}>State</InputLabel>
           <Select
+            id="state-select"
+            name="state-select"
+            autoComplete="off"
             value={tab === 0 ? issueFilter : prFilter}
             onChange={(e) =>
               tab === 0
@@ -320,7 +323,7 @@ const Home: React.FC = () => {
             <MenuItem value="open">Open</MenuItem>
             <MenuItem value="closed">Closed</MenuItem>
             {tab === 1 && <MenuItem value="merged">Merged</MenuItem>}
-          </Select>
+          </Select> 
         </FormControl>
       </Box>
 


### PR DESCRIPTION
## Related Issue
Closes #388

---

## Description
Added missing `id`, `name`, and `label` attributes to form fields across the application to resolve accessibility warnings.

**Files changed:**
- `src/components/Footer.tsx` - newsletter email input
- `src/pages/Contact/Contact.tsx` - name, email, subject, message fields
- `src/pages/Login/Login.tsx` - email, password fields
- `src/pages/Signup/Signup.tsx` - username, email, password fields
- `src/pages/Tracker/Tracker.tsx` - MUI Select component (State filter)

**Changes made:**
- Added `id` and `name` attributes to all form inputs
- Added associated `<label>` tags with `htmlFor` matching the `id`
- Added `autoComplete="off"` to MUI Select component
- Used `sr-only` class for screen-reader accessible labels

---

## How Has This Been Tested?
1. Ran `npm run dev` locally
2. Opened browser console (F12)
3. Verified that the warning "A form field element should have an id or name attribute" no longer appears
4. Tested all forms (Login, Signup, Contact) to ensure they still work correctly

---

## Screenshot (After Fix)
The original warning "A form field element should have an id or name attribute" is **gone**. Only unrelated autocomplete and label warnings remain (separate issues).
<img width="921" height="1022" alt="Screenshot 2026-05-22 140350" src="https://github.com/user-attachments/assets/52bf3f51-6e63-480e-b288-38365b5ff115" />

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility Improvements**
  * Enhanced form accessibility across the application by adding screen-reader-friendly labels and proper form field associations to newsletter subscription, contact, login, signup, and tracker filter forms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->