### PR TITLE
fix: add autocomplete email attribute to newsletter form (#400)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -99,6 +99,7 @@ function Footer() {
                 placeholder="Enter email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
                 className="
                   flex-grow text-sm px-4 py-3
                   bg-zinc-50 dark:bg-zinc-800/40


### PR DESCRIPTION
### Related Issue
- Closes: #400

---

### Description
Added `autoComplete="email"` to the newsletter subscription email input in Footer component to resolve the console warning.

---

### How Has This Been Tested?
1. Ran `npm run dev` locally
2. Opened browser console (F12)
3. Verified the autocomplete warning no longer appears

---

### Screenshots (if applicable)
Console is clean - no autocomplete warning visible.
<img width="938" height="1032" alt="Screenshot 2026-05-22 144712" src="https://github.com/user-attachments/assets/9eacad04-e36b-4a1f-8adf-d2d3c80c3708" />

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update