### PR TITLE
fix(server): restrict CORS to allowed origin from env variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+SESSION_SECRET=your_strong_random_secret_here
+MONGO_URI=mongodb://localhost:27017/github_tracker
+PORT=5000
+CLIENT_URL=http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,7 +14,10 @@ const logger = require('./logger');
 const app = express();
 
 // CORS configuration
-app.use(cors('*'));
+app.use(cors({
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  credentials: true,
+}));
 
 // Middleware
 app.use(bodyParser.json());


### PR DESCRIPTION
### Related Issue
- Closes: #367 

---

### Description
The server used cors() with no origin restriction, allowing any
domain to make credentialed API requests - a security risk.

Replaced with an explicit origin config that reads CLIENT_URL
from environment variables, falling back to localhost:5173 for
local dev. Added credentials: true so session cookies continue
working cross-origin.

- `backend/server.js` : updated CORS configuration
- `backend/.env.example` : added CLIENT_URL variable

---

### How Has This Been Tested?
- Verified login and API calls work normally from the frontend
- Confirmed requests from unlisted origins are blocked

---

### Screenshots (if applicable)


---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration template for server setup and initialization.
  * Updated cross-origin request policy to allow only authorized client domains, enhancing server security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->