### PR TITLE
[Security] Harden session cookie with HttpOnly, Secure, and SameSite flags

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -13,6 +13,9 @@ RUN npm install --production
 # Copy the rest of the application files
 COPY . .
 
+# Set production environment so cookie security flags are applied
+ENV NODE_ENV=production
+
 # Expose the port for the application
 EXPOSE 5000
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,12 @@ app.use(session({
     secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
+    cookie: {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax',
+        maxAge: 24 * 60 * 60 * 1000,
+    },
 }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
## Problem

`backend/server.js` configured `express-session` with no cookie security attributes. The resulting `connect.sid` cookie had:

- No `HttpOnly` flag — JavaScript running in the page (including any XSS gadget or compromised npm package) could read `document.cookie` and exfiltrate the session ID, achieving full account takeover.
- No `Secure` flag — the cookie was transmitted over plain HTTP, allowing any network observer on shared Wi-Fi, an ISP, or a transparent proxy to capture and replay the session ID.
- No `SameSite` flag — cross-site requests (e.g. an `<img>` tag on a third-party page pointing at `/api/auth/logout`) automatically carried the cookie, enabling CSRF attacks on all current and future authenticated endpoints.

Additionally, `backend/Dockerfile.prod` did not set `NODE_ENV=production`, so the `secure: process.env.NODE_ENV === 'production'` check would never activate in the containerised deployment.

## Changes

**`backend/server.js`**
- Added `cookie` block to the `express-session` configuration with:
  - `httpOnly: true` — cookie is invisible to JavaScript in all environments
  - `secure: process.env.NODE_ENV === 'production'` — HTTPS-only in production
  - `sameSite: 'strict'` in production, `'lax'` in development — blocks cross-site cookie sending while keeping local dev workflow functional
  - `maxAge: 24 * 60 * 60 * 1000` — 24-hour expiry

**`backend/Dockerfile.prod`**
- Added `ENV NODE_ENV=production` so the `secure` flag correctly activates when the container is deployed.

## Why this approach fixes the root cause

The three flags address three independent attack vectors at the browser level before any application logic runs. Setting `secure` conditionally on `NODE_ENV` preserves the local development experience (HTTP over localhost) while enforcing HTTPS-only in production. Setting `sameSite: 'strict'` in production eliminates the CSRF surface on all authenticated endpoints without requiring per-endpoint CSRF token middleware.

## Steps to test

1. Start the backend (`npm start` in `backend/`).
2. POST to `/api/auth/login` with valid credentials.
3. Inspect the `Set-Cookie` response header — confirm it contains `HttpOnly`, `SameSite=Lax` (dev), and no `Secure` flag in dev mode.
4. Build and run the production Docker image (`docker build -f Dockerfile.prod -t tracker-prod .`).
5. POST to `/api/auth/login` — confirm `Set-Cookie` now shows `Secure; HttpOnly; SameSite=Strict`.
6. In a browser console on the running app, run `document.cookie` — confirm `connect.sid` is not present.

## Edge cases covered

- Development (HTTP localhost) — `SameSite=Lax` and no `Secure` flag so login still works without HTTPS.
- Production Docker deployment — `NODE_ENV=production` is set in the Dockerfile, activating `Secure` and `SameSite=Strict` automatically.
- Any XSS injection attempt — `HttpOnly` blocks cookie access in all environments.

## Regression check

No existing routes, middleware, or tests were modified. Session serialization/deserialization logic in `passportConfig.js` is unchanged. The cookie attribute changes are transparent to all application code that reads from `req.session` or `req.user`.

Please review and merge this under GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured production environment settings for container deployment
  * Enhanced session security with improved cookie protection settings including HTTP-only protection and same-site policies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->