### PR TITLE
[Security] Replace wildcard CORS with environment-driven origin allowlist

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,3 +1,4 @@
 PORT=5000
 MONGO_URI=mongodb://localhost:27017/githubTracker
 SESSION_SECRET=your-secret-key
+ALLOWED_ORIGINS=http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,8 +11,23 @@ require('./config/passportConfig');
 
 const app = express();
 
-// CORS configuration
-app.use(cors('*'));
+// CORS configuration — restrict to known frontend origins only
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:5173')
+    .split(',')
+    .map(o => o.trim());
+
+app.use(cors({
+    origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true);
+        } else {
+            callback(new Error('Not allowed by CORS'));
+        }
+    },
+    credentials: true,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type'],
+}));
 
 // Middleware
 app.use(bodyParser.json());


### PR DESCRIPTION
## Problem

`backend/server.js` line 15 applied `app.use(cors('*'))` — a fully open wildcard CORS policy across every API endpoint. This instructs browsers to allow any origin to read API responses, completely nullifying the Same-Origin Policy as a defence layer.

**Concrete impact:**
- Any page on the internet (including `file://`, `http://attacker.com`) could call `POST /api/auth/signup` or `POST /api/auth/login` and read the full JSON response with no browser restriction.
- Every new endpoint added by any contributor was silently exposed by default with no per-origin security review needed — a permanent attack surface expansion vector as the API grows.
- Combined with the differential error messages in `passportConfig.js`, a cross-origin script could enumerate the entire registered user database in seconds.

## Changes

**`backend/server.js`**
- Removed `cors('*')`.
- Replaced with an explicit origin allowlist built from `process.env.ALLOWED_ORIGINS` (comma-separated), defaulting to `http://localhost:5173` so local development works out of the box.
- Added `credentials: true` to allow session cookies in cross-origin requests from the allowlisted frontend.
- Restricted `methods` to `['GET', 'POST']` and `allowedHeaders` to `['Content-Type']` — minimises the CORS surface as the API grows.
- Server-to-server requests (no `Origin` header) are still allowed for health checks and internal tooling.

**`backend/.env.sample`**
- Added `ALLOWED_ORIGINS=http://localhost:5173` so contributors know to set this variable for their deployment environment.

## Why this approach fixes the root cause

The wildcard policy was a blanket grant at the infrastructure level. Replacing it with an environment-variable-driven allowlist means the set of trusted origins is explicit, auditable, and different per environment — `http://localhost:5173` for dev, the production domain for prod — without any code change required between environments.

## Steps to test

1. Start the backend (`npm start` in `backend/`).
2. From a browser console on `http://localhost:5173`, call `POST /api/auth/signup` — request succeeds (allowlisted origin).
3. Open `http://localhost:5174` (a different port) and repeat the fetch — browser blocks the request with a CORS error.
4. Confirm the `Access-Control-Allow-Origin` response header shows `http://localhost:5173`, not `*`.
5. Set `ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174` in `.env` and restart — both origins are now accepted.
6. Confirm server-to-server calls (e.g. `curl -X POST ...` with no `Origin` header) still work.

## Edge cases covered

- Requests with no `Origin` header (server-to-server, curl) — allowed, as the `!origin` guard passes them through.
- Multiple production origins — supported via comma-separated `ALLOWED_ORIGINS`.
- Unlisted origins — receive a CORS error from the browser; no response body is readable.

## Regression check

All existing routes (`/api/auth/signup`, `/api/auth/login`, `/api/auth/logout`) continue to work normally from `http://localhost:5173`. The `credentials: true` flag ensures session cookies are forwarded correctly from the frontend. No changes to route handlers, middleware order, or tests.

Please review and merge this under GSSoC 2026.