### PR TITLE
[Security] Block cross-origin account enumeration by removing wildcard CORS

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,3 +1,4 @@
 PORT=5000
 MONGO_URI=mongodb://localhost:27017/githubTracker
 SESSION_SECRET=your-secret-key
+ALLOWED_ORIGINS=http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,8 +11,21 @@ require('./config/passportConfig');
 
 const app = express();
 
-// CORS configuration
-app.use(cors('*'));
+// CORS configuration — restrict to known frontend origins only
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:5173')
+    .split(',')
+    .map(o => o.trim());
+
+app.use(cors({
+    origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true);
+        } else {
+            callback(new Error('Not allowed by CORS'));
+        }
+    },
+    credentials: true,
+}));
 
 // Middleware
 app.use(bodyParser.json());


### PR DESCRIPTION
## Problem

`backend/server.js` applied `app.use(cors('*'))` globally. This allowed JavaScript running on **any** origin to call `POST /api/auth/signup` and read the full response body — no browser restriction applied.

**Concrete attack:**
```js
// Run from https://evil.com or even file://
fetch('http://localhost:5000/api/auth/signup', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ username: 'probe', email: 'victim@example.com', password: 'Aa1@aaaa' })
}).then(r => r.json()).then(console.log);
// 400 "User already exists" → email is registered
// 201 "User created successfully" → email is free
```

An attacker could automate this across millions of email addresses in minutes, building a full map of registered accounts with zero rate-limit bypass required. Those accounts could then be targeted for phishing or credential stuffing. Additionally, any future authenticated endpoint is exposed by default the moment it is added — the wildcard is a permanent silent grant.

## Changes

**`backend/server.js`**
- Removed `cors('*')`.
- Replaced with an explicit origin allowlist read from `process.env.ALLOWED_ORIGINS` (comma-separated), defaulting to `http://localhost:5173`.
- Added `credentials: true` so session cookies flow correctly from the allowlisted frontend.
- Server-to-server requests (no `Origin` header) pass through unchanged.

**`backend/.env.sample`**
- Added `ALLOWED_ORIGINS=http://localhost:5173` so all contributors know to configure this for their deployment environment.

## Why this approach fixes the root cause

The wildcard was a blanket grant at the infrastructure level — any fix to individual routes would be incomplete because the problem recurs for every new endpoint. Replacing it with an env-var-driven allowlist means the trusted origin set is explicit, per-environment, and auditable. A cross-origin probe from an unlisted origin now receives a CORS error and cannot read the response.

## Steps to test

1. Start the backend with default `.env` (`ALLOWED_ORIGINS=http://localhost:5173`).
2. From `http://localhost:5173`, `POST /api/auth/signup` — succeeds (allowlisted).
3. Open DevTools on `http://localhost:5174` and repeat — browser blocks with CORS error, response is unreadable.
4. Confirm `Access-Control-Allow-Origin` in the response header shows `http://localhost:5173`, not `*`.
5. `curl -X POST http://localhost:5000/api/auth/signup ...` (no Origin header) — still works for server-to-server calls.
6. Add `http://localhost:5174` to `ALLOWED_ORIGINS`, restart — both ports accepted.

## Edge cases covered

- No `Origin` header (curl, health checks, internal tooling) — allowed via the `!origin` guard.
- Multiple allowed origins — supported via comma-separated `ALLOWED_ORIGINS`.
- Any unlisted origin — CORS error, response body never readable by the caller.
- Session cookie forwarding — `credentials: true` ensures cookies flow from the allowlisted frontend.

## Regression check

No route handlers, session logic, validators, or tests were changed. All existing endpoints continue to work normally from `http://localhost:5173`. The only behaviour change is that requests from non-allowlisted origins are now rejected by the browser.

Please review and merge this under GSSoC 2026.