### PR TITLE
[Security] Fix session cookie flags and strip internal errors from API responses

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -26,7 +26,7 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
             return res.status(400).json({ message: 'User already exists' });
         }
 
-        res.status(500).json({ message: 'Error creating user', error: err.message });
+        res.status(500).json({ message: 'Error creating user' });
     }
 });
 
@@ -41,7 +41,7 @@ router.get("/logout", (req, res) => {
     req.logout((err) => {
 
         if (err)
-            return res.status(500).json({ message: 'Logout failed', error: err.message });
+            return res.status(500).json({ message: 'Logout failed' });
         else
             res.status(200).json({ message: 'Logged out successfully' });
     });

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,12 @@ app.use(session({
     secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
+    cookie: {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 24 * 60 * 60 * 1000,
+    },
 }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
## Problem

This PR addresses two independent but related HIGH-severity vulnerabilities in the backend.

### 1 — Session cookie missing security attributes (`backend/server.js` lines 19–23)

The `express-session` config had no `cookie` block, so the resulting `connect.sid` cookie carried none of the standard security flags:

- **No `httpOnly`** — `document.cookie` returned the raw session ID from the browser console, meaning any XSS gadget or compromised npm package could exfiltrate it and achieve full account takeover.
- **No `secure`** — the cookie was transmitted over plain HTTP, allowing a network observer on shared Wi-Fi or a transparent proxy to capture and replay it.
- **No `sameSite`** — cross-site requests (e.g. an `<img>` on a third-party page targeting `/api/auth/logout`) automatically carried the session cookie, enabling CSRF on all current and future authenticated endpoints.

### 2 — Raw MongoDB error internals returned in 500 responses (`backend/routes/auth.js` lines 29 and 44)

Both 500 error handlers returned `err.message` verbatim:
- Signup catch: `{ message: 'Error creating user', error: err.message }` — a duplicate-key violation exposes the full MongoDB error string including collection name, index name, and key value: `E11000 duplicate key error collection: githubTracker.users index: email_1 dup key: { email: "..." }`.
- Logout catch: `{ message: 'Logout failed', error: err.message }` — any session store error leaks internal implementation details.

This fingerprints the database engine, collection structure, and index naming, narrowing the attack surface for further exploitation.

## Changes

**`backend/server.js`**
- Added `cookie` block to the `express-session` configuration:
  - `httpOnly: true` — session ID invisible to JavaScript in all environments
  - `secure: process.env.NODE_ENV === 'production'` — HTTPS-only in production, HTTP allowed in local dev
  - `sameSite: 'strict'` — cross-site requests never carry the cookie
  - `maxAge: 24 * 60 * 60 * 1000` — 24-hour session expiry

**`backend/routes/auth.js`**
- Line 29: removed `error: err.message` from the signup 500 response
- Line 44: removed `error: err.message` from the logout 500 response

Both handlers now return only the generic message string — no internal state is disclosed.

## Why this approach fixes the root cause

The cookie flags operate at the browser level before any application logic runs — they cannot be bypassed by an attacker who has already obtained a gadget in the page without the `httpOnly` flag. Stripping `err.message` from 500 responses is a boundary decision: internal errors belong in server-side logs, not in API responses visible to callers.

## Steps to test

1. Start the backend (`npm start` in `backend/`).
2. `POST /api/auth/login` with valid credentials. Open DevTools → Application → Cookies — confirm `connect.sid` shows `HttpOnly` and `SameSite=Strict`.
3. In the browser console, run `document.cookie` — confirm `connect.sid` is **not** present.
4. Trigger a duplicate-key 500 on signup (register the same email twice after removing the pre-check temporarily) — confirm the response body contains only `{ "message": "Error creating user" }` with no MongoDB error string.
5. Set `NODE_ENV=production` and restart — confirm the `Secure` flag now appears on the cookie.

## Edge cases covered

- Development (HTTP localhost) — `secure` is `false` so login still works without HTTPS.
- Production — `secure: true` enforces HTTPS-only cookie transmission.
- Any XSS gadget — `httpOnly: true` blocks cookie access in all environments.
- Duplicate-key or any other MongoDB 500 — only the generic message is returned.
- Logout session-store failure — only the generic message is returned.

## Regression check

No route logic, validators, passport config, or tests were changed. Session serialization/deserialization in `passportConfig.js` is untouched. The cookie attribute additions are transparent to all code that reads from `req.session` or `req.user`.

Please review and merge this under GSSoC 2026.