### PR TITLE
fix(signup): align frontend password validation with backend Zod schema

### DIFF
--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -8,6 +8,13 @@ import type { ThemeContextType } from "../../context/ThemeContext";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
+// Must mirror the Zod rule in backend/validators/authValidator.js exactly.
+// Requires: lowercase, uppercase, digit, and one special character from @$!%*?&
+// Minimum 8 characters, maximum enforced by the backend (100).
+const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+const PASSWORD_ERROR =
+  "Password must be at least 8 characters and include uppercase, lowercase, a number, and a special character (@$!%*?&)";
+
 interface SignUpFormData {
   username: string;
   email: string;
@@ -53,8 +60,8 @@ const SignUp: React.FC = () => {
     if (name === "password") {
       if (!value.trim()) {
         errorMessage = "Password is required";
-      } else if (!/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@$!%*#?&]{8,}$/.test(value)) {
-        errorMessage = "Password must be 8+ characters with letters and numbers";
+      } else if (!PASSWORD_REGEX.test(value)) {
+        errorMessage = PASSWORD_ERROR;
       }
     }
     setErrors((prev) => ({ ...prev, [name]: errorMessage }));
@@ -74,8 +81,8 @@ const SignUp: React.FC = () => {
       : "";
     const passwordError = !formData.password.trim()
       ? "Password is required"
-      : !/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d@$!%*#?&]{8,}$/.test(formData.password)
-      ? "Password must be 8+ characters with letters and numbers"
+      : !PASSWORD_REGEX.test(formData.password)
+      ? PASSWORD_ERROR
       : "";
     if (usernameError || emailError || passwordError) {
       setErrors({ username: usernameError, email: emailError, password: passwordError });


### PR DESCRIPTION
## Summary

Fixes #415

The password regex in `Signup.tsx` was weaker than the Zod schema in `backend/validators/authValidator.js`, creating a class of passwords that cleared the frontend check but were rejected by the server with a generic error and no inline guidance.

### Mismatch table (before this fix)

| Password | Frontend | Backend |
|---|---|---|
| `password1` | Valid | Rejected (no uppercase, no special char) |
| `Password1` | Valid | Rejected (no special char) |
| `Password1#` | Valid (`#` allowed by old frontend regex) | Rejected (`#` not in backend allowlist) |
| `Password1!` | Valid | Valid |

### Changes in `src/pages/Signup/Signup.tsx`

1. **Extracted `PASSWORD_REGEX` constant** placed at module level so there is a single source of truth rather than the same regex copy-pasted in two places:

```ts
const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
```

This is an exact copy of the Zod `.regex(...)` in `authValidator.js`, with `{8,}` appended to the character class to also enforce the `.min(8)` constraint inline.

2. **Replaced both usages** of the old regex in `handleChange` and `handleSubmit` with `PASSWORD_REGEX`.

3. **Updated the error message** from the vague `"Password must be 8+ characters with letters and numbers"` to a descriptive `"Password must be at least 8 characters and include uppercase, lowercase, a number, and a special character (@$!%*?&)"` so users know exactly what is required without trial and error.

No backend changes: `authValidator.js` is already correct and serves as the reference.

## Test plan

- [ ] Enter `password1` in the password field: inline error appears immediately
- [ ] Enter `Password1` in the password field: inline error appears (no special char)
- [ ] Enter `Password1#` in the password field: inline error appears (`#` not allowed)
- [ ] Enter `Password1!` in the password field: no error shown, submit succeeds
- [ ] Submit with each of the above: confirm the frontend blocks submission before the network request is made for the invalid cases
- [ ] Confirm the error message text lists all four requirements clearly