### PR TITLE
fix: align frontend username validation with backend Zod schema

### DIFF
--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -8,6 +8,14 @@ import type { ThemeContextType } from "../../context/ThemeContext";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL;
 
+// Username rules -- must mirror backend/validators/authValidator.js exactly.
+// Accepted characters: letters (a-z, A-Z), digits (0-9), and underscores.
+// Length: minimum 3, maximum 30 characters.
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+const USERNAME_MIN = 3;
+const USERNAME_MAX = 30;
+const USERNAME_ERROR = "Username can only contain letters, numbers, and underscores";
+
 interface SignUpFormData {
   username: string;
   email: string;
@@ -39,8 +47,12 @@ const SignUp: React.FC = () => {
     if (name === "username") {
       if (!value.trim()) {
         errorMessage = "Username is required";
-      } else if (!/^[A-Za-z\s]+$/.test(value)) {
-        errorMessage = "Only letters are allowed";
+      } else if (value.trim().length < USERNAME_MIN) {
+        errorMessage = `Username must be at least ${USERNAME_MIN} characters long`;
+      } else if (value.trim().length > USERNAME_MAX) {
+        errorMessage = `Username must be at most ${USERNAME_MAX} characters long`;
+      } else if (!USERNAME_REGEX.test(value.trim())) {
+        errorMessage = USERNAME_ERROR;
       }
     }
     if (name === "email") {
@@ -62,10 +74,15 @@ const SignUp: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const usernameError = !formData.username.trim()
+    const trimmedUsername = formData.username.trim();
+    const usernameError = !trimmedUsername
       ? "Username is required"
-      : !/^[A-Za-z\s]+$/.test(formData.username)
-      ? "Only letters are allowed"
+      : trimmedUsername.length < USERNAME_MIN
+      ? `Username must be at least ${USERNAME_MIN} characters long`
+      : trimmedUsername.length > USERNAME_MAX
+      ? `Username must be at most ${USERNAME_MAX} characters long`
+      : !USERNAME_REGEX.test(trimmedUsername)
+      ? USERNAME_ERROR
       : "";
     const emailError = !formData.email.trim()
       ? "Email is required"


### PR DESCRIPTION
Fixes #413

## Problem

The frontend signup form in `src/pages/Signup/Signup.tsx` validated usernames against `/^[A-Za-z\s]+$/` (letters and spaces only). The backend Zod schema in `backend/validators/authValidator.js` accepts a completely different character set:

```js
username: z.string()
  .min(3, "Username must be at least 3 characters long")
  .max(30, "Username must be at most 30 characters long")
  .regex(/^[a-zA-Z0-9_]+$/, "Username can only contain letters, numbers, and underscores")
```

This produced two failure modes:

**Mode 1 -- valid usernames blocked at the frontend**
Usernames like `dev_user1` or `john99` are accepted by the backend but were rejected by the frontend with the misleading error "Only letters are allowed". Users with common username patterns could not register at all.

**Mode 2 -- invalid usernames accepted by the frontend, rejected by the backend**
Usernames containing spaces (e.g. `john doe`) passed the frontend check but were rejected by the backend after the network request was made, surfacing as a confusing server-side error rather than an inline form error.

**Mode 3 -- length constraints missing from the frontend**
The backend enforces `min(3)` and `max(30)`. The frontend had no length checks, so a 1 or 2-character username would pass client-side validation and produce a backend rejection instead of an immediate inline error.

## Fix

**`src/pages/Signup/Signup.tsx`**

Added named module-level constants that document the backend rule and serve as a single place to update when the backend schema changes:

```tsx
const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
const USERNAME_MIN = 3;
const USERNAME_MAX = 30;
const USERNAME_ERROR = "Username can only contain letters, numbers, and underscores";
```

Updated both validation sites (`handleChange` for inline feedback and `handleSubmit` for pre-submit guard) to:
- Check minimum length (3 characters)
- Check maximum length (30 characters)
- Test the corrected regex against the trimmed value
- Use `USERNAME_ERROR` to match the backend error message exactly

The `handleSubmit` block now trims the username once into a local variable before the validation chain, removing repeated `.trim()` calls.

## Testing

| Input | Before | After |
|---|---|---|
| `dev_user1` | "Only letters are allowed" (blocked) | accepted |
| `john_doe` | "Only letters are allowed" (blocked) | accepted |
| `john doe` | accepted (then backend rejects) | "Username can only contain letters, numbers, and underscores" |
| `ab` | accepted (then backend rejects) | "Username must be at least 3 characters long" |
| `a` * 31 | accepted (then backend rejects) | "Username must be at most 30 characters long" |
| `alice` | accepted | accepted |