### PR TITLE
fix(security): replace wildcard CORS with allowlist and harden session cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# URL of the backend API (no trailing slash).
+# Must match the origin the backend server listens on.
+VITE_BACKEND_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -51,14 +51,35 @@ $ git clone https://github.com/yourusername/github-tracker.git
 $ cd github-tracker
 ```
 
-3. Run the frontend
+3. Configure environment variables
+
+   Copy the example files and fill in your values:
+   ```bash
+   # Frontend (.env in the repo root)
+   cp .env.example .env
+
+   # Backend (.env inside backend/)
+   cp backend/.env.example backend/.env
+   ```
+
+   Key variables to set:
+
+   | Variable | Where | Description |
+   |---|---|---|
+   | `VITE_BACKEND_URL` | root `.env` | URL of the backend (default: `http://localhost:5000`) |
+   | `MONGO_URI` | `backend/.env` | MongoDB connection string |
+   | `SESSION_SECRET` | `backend/.env` | Long random string used to sign session cookies |
+   | `FRONTEND_ORIGIN` | `backend/.env` | URL of the frontend — restricts CORS. **Required in production.** Defaults to `http://localhost:5173` in development. |
+
+4. Run the frontend
 ```bash
 $ npm i
 $ npm run dev
 ```
 
-4. Run the backend
+5. Run the backend
 ```bash
+$ cd backend
 $ npm i
 $ npm start
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,37 @@
+# ---------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------
+PORT=5000
+NODE_ENV=development
+
+# ---------------------------------------------------------------
+# MongoDB
+# ---------------------------------------------------------------
+MONGO_URI=mongodb://127.0.0.1:27017/github_tracker
+
+# ---------------------------------------------------------------
+# Session
+# Generate a long random string for production, e.g.:
+#   node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+# ---------------------------------------------------------------
+SESSION_SECRET=replace-with-a-long-random-string
+
+# ---------------------------------------------------------------
+# CORS — Frontend origin allowlist
+#
+# Set this to the exact URL of your frontend (no trailing slash).
+# REQUIRED in production: the server will refuse to start without it.
+# In development, the server defaults to http://localhost:5173 when
+# this variable is not set.
+#
+# Examples:
+#   Development : FRONTEND_ORIGIN=http://localhost:5173
+#   Production  : FRONTEND_ORIGIN=https://app.example.com
+# ---------------------------------------------------------------
+FRONTEND_ORIGIN=http://localhost:5173
+
+# ---------------------------------------------------------------
+# Logging
+# Accepted values: error | warn | info | debug
+# ---------------------------------------------------------------
+LOG_LEVEL=debug

--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -1,0 +1,15 @@
+/**
+ * Validates required environment variables before the server starts.
+ * Throws so callers can decide whether to log + exit or handle otherwise,
+ * which keeps the logic unit-testable without spawning child processes.
+ */
+function validateEnv() {
+  if (process.env.NODE_ENV === 'production' && !process.env.FRONTEND_ORIGIN) {
+    throw new Error(
+      'FRONTEND_ORIGIN environment variable is required in production. ' +
+      'Set it to the URL of your frontend (e.g., https://app.example.com).'
+    );
+  }
+}
+
+module.exports = { validateEnv };

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "jasmine": "^5.0.0",
+    "nodemon": "^3.1.9",
+    "supertest": "^7.0.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,22 +6,62 @@ const bodyParser = require('body-parser');
 require('dotenv').config();
 const cors = require('cors');
 
+const { validateEnv } = require('./config/validateEnv');
+const logger = require('./logger');
+
+// Fail fast in production when required env vars are absent.
+try {
+  validateEnv();
+} catch (err) {
+  logger.error(`[FATAL] ${err.message}`);
+  process.exit(1);
+}
+
 // Passport configuration
 require('./config/passportConfig');
 
-const logger = require('./logger');
-
 const app = express();
 
-// CORS configuration
-app.use(cors('*'));
+// In development, fall back to localhost:5173 if FRONTEND_ORIGIN is not set so
+// that contributors can run the stack without a full .env file.
+const corsOrigin = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+
+if (!process.env.FRONTEND_ORIGIN) {
+  logger.warn(
+    'FRONTEND_ORIGIN is not set; defaulting to http://localhost:5173. ' +
+    'Set this variable in production.'
+  );
+}
+
+// CORS — explicit allowlist with credentials support.
+// A function-based origin is required so that the header is only set (and
+// reflected) for allowed origins; a static string would send the header on
+// every response regardless of the requesting origin.
+app.use(cors({
+  origin: (requestOrigin, callback) => {
+    // Allow same-origin requests (no Origin header) and the configured origin.
+    if (!requestOrigin || requestOrigin === corsOrigin) {
+      return callback(null, true);
+    }
+    callback(null, false);
+  },
+  credentials: true,
+  methods: ['GET', 'POST'],
+  allowedHeaders: ['Content-Type'],
+}));
 
 // Middleware
 app.use(bodyParser.json());
 app.use(session({
-    secret: process.env.SESSION_SECRET,
-    resave: false,
-    saveUninitialized: false,
+  secret: process.env.SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    httpOnly: true,
+    // Only transmit the cookie over HTTPS in production.
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+  },
 }));
 app.use(passport.initialize());
 app.use(passport.session());
@@ -32,10 +72,10 @@ app.use('/api/auth', authRoutes);
 
 // Connect to MongoDB
 mongoose.connect(process.env.MONGO_URI, {}).then(() => {
-    logger.info('Connected to MongoDB');
-    app.listen(process.env.PORT, () => {
-        logger.info(`Server running on port ${process.env.PORT}`);
-    });
+  logger.info('Connected to MongoDB');
+  app.listen(process.env.PORT, () => {
+    logger.info(`Server running on port ${process.env.PORT}`);
+  });
 }).catch((err) => {
-    logger.error('MongoDB connection error', err);
+  logger.error('MongoDB connection error', err);
 });

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.3",
+    "cors": "^2.8.5",
 
     "eslint": "^9.13.0",
     "eslint-plugin-react": "^7.37.2",

--- a/spec/auth.routes.spec.cjs
+++ b/spec/auth.routes.spec.cjs
@@ -1,15 +1,44 @@
-const mongoose = require('mongoose');
 const express = require('express');
 const request = require('supertest');
-const session = require('express-session');
-const passport = require('passport');
+const cors = require('cors');
 
-const User = require('../backend/models/User');
+// All backend modules are resolved from the backend directory so the test app
+// and the application code share a single instance of each module — avoids
+// connection-state mismatches that arise when backend/node_modules is present
+// alongside the root node_modules.
+const backendPath = [`${__dirname}/../backend`];
+
+const mongoose = require(require.resolve('mongoose', { paths: backendPath }));
+const session  = require(require.resolve('express-session', { paths: backendPath }));
+const passport = require(require.resolve('passport', { paths: backendPath }));
+
+const User       = require('../backend/models/User');
 const authRoutes = require('../backend/routes/auth');
+const { validateEnv } = require('../backend/config/validateEnv');
 
-// Create test app
+// A fixed allowed origin used throughout the test suite.
+const ALLOWED_ORIGIN = 'http://localhost:5173';
+
+// Password satisfying the signup Zod schema (uppercase + lowercase + digit + special).
+const VALID_PASSWORD = 'TestPass1!';
+
 function createTestApp() {
   const app = express();
+
+  // Mirror the production CORS config: function-based origin so the header is
+  // only reflected for the configured origin, absent for all others.
+  const allowedOrigin = process.env.FRONTEND_ORIGIN || ALLOWED_ORIGIN;
+  app.use(cors({
+    origin: (requestOrigin, callback) => {
+      if (!requestOrigin || requestOrigin === allowedOrigin) {
+        return callback(null, true);
+      }
+      callback(null, false);
+    },
+    credentials: true,
+    methods: ['GET', 'POST'],
+    allowedHeaders: ['Content-Type'],
+  }));
 
   app.use(express.json());
 
@@ -18,13 +47,15 @@ function createTestApp() {
       secret: 'test-secret',
       resave: false,
       saveUninitialized: false,
+      // Mirror production cookie options; secure:false is correct for HTTP tests.
+      cookie: { httpOnly: true, secure: false, sameSite: 'strict' },
     })
   );
 
   app.use(passport.initialize());
   app.use(passport.session());
 
-  // Load passport config AFTER initializing passport
+  // Load passport config AFTER initializing passport.
   require('../backend/config/passportConfig');
 
   app.use('/auth', authRoutes);
@@ -32,10 +63,16 @@ function createTestApp() {
   return app;
 }
 
-describe('Auth Routes', () => {
+// ---------------------------------------------------------------------------
+// Integration tests that require a running MongoDB instance.
+// All MongoDB-dependent suites live inside one outer describe so they share
+// a single connection, unaffected by Jasmine's random suite ordering.
+// ---------------------------------------------------------------------------
+describe('Backend auth integration', () => {
   let app;
 
   beforeAll(async () => {
+    process.env.FRONTEND_ORIGIN = ALLOWED_ORIGIN;
     await mongoose.connect('mongodb://127.0.0.1:27017/github_tracker_test');
     app = createTestApp();
   });
@@ -52,96 +89,259 @@ describe('Auth Routes', () => {
   });
 
   // ---------------- SIGNUP ----------------
-  it('should sign up a new user', async () => {
-    const res = await request(app)
-      .post('/auth/signup')
-      .send({
+  describe('Auth Routes', () => {
+    it('should sign up a new user', async () => {
+      const res = await request(app)
+        .post('/auth/signup')
+        .send({
+          username: 'testuser',
+          email: 'test@example.com',
+          password: VALID_PASSWORD,
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.message).toBe('User created successfully');
+
+      const user = await User.findOne({ email: 'test@example.com' });
+      expect(user).toBeTruthy();
+    });
+
+    it('should not sign up a user with an existing email', async () => {
+      await User.create({
         username: 'testuser',
         email: 'test@example.com',
-        password: 'password123',
+        password: VALID_PASSWORD,
       });
 
-    expect(res.status).toBe(201);
-    expect(res.body.message).toBe('User created successfully');
+      const res = await request(app)
+        .post('/auth/signup')
+        .send({
+          username: 'testuser2',
+          email: 'test@example.com',
+          password: VALID_PASSWORD,
+        });
 
-    const user = await User.findOne({ email: 'test@example.com' });
-    expect(user).toBeTruthy();
-  });
-
-  it('should not sign up a user with existing email', async () => {
-    await User.create({
-      username: 'testuser',
-      email: 'test@example.com',
-      password: 'password123',
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('User already exists');
     });
 
-    const res = await request(app)
-      .post('/auth/signup')
-      .send({
-        username: 'testuser2',
+    // ---------------- LOGIN ----------------
+    it('should login a user with correct credentials', async () => {
+      await User.create({
+        username: 'testuser',
         email: 'test@example.com',
-        password: 'password456',
+        password: VALID_PASSWORD,
       });
 
-    expect(res.status).toBe(400);
-    expect(res.body.message).toBe('User already exists');
+      const agent = request.agent(app);
+
+      const res = await agent.post('/auth/login').send({
+        email: 'test@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Login successful');
+      expect(res.body.user.email).toBe('test@example.com');
+    });
+
+    it('should reject login with the wrong password', async () => {
+      await User.create({
+        username: 'testuser',
+        email: 'test@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      const agent = request.agent(app);
+
+      const res = await agent.post('/auth/login').send({
+        email: 'test@example.com',
+        password: 'wrongpassword',
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    // ---------------- LOGOUT ----------------
+    it('should logout a logged-in user', async () => {
+      const agent = request.agent(app);
+
+      await agent.post('/auth/signup').send({
+        username: 'testuser',
+        email: 'test@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      await agent.post('/auth/login').send({
+        email: 'test@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      const res = await agent.get('/auth/logout');
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Logged out successfully');
+    });
   });
 
-  // ---------------- LOGIN ----------------
-  it('should login a user with correct credentials', async () => {
-    await User.create({
-      username: 'testuser',
-      email: 'test@example.com',
-      password: 'password123',
+  // ---------------- CORS BEHAVIOUR ----------------
+  describe('CORS behaviour', () => {
+    it('should include Access-Control-Allow-Origin for the configured origin', async () => {
+      const res = await request(app)
+        .get('/auth/logout')
+        .set('Origin', ALLOWED_ORIGIN);
+
+      expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
     });
 
-    const agent = request.agent(app);
+    it('should include Access-Control-Allow-Credentials: true for the allowed origin', async () => {
+      const res = await request(app)
+        .get('/auth/logout')
+        .set('Origin', ALLOWED_ORIGIN);
 
-    const res = await agent.post('/auth/login').send({
-      email: 'test@example.com',
-      password: 'password123',
+      expect(res.headers['access-control-allow-credentials']).toBe('true');
     });
 
-    expect(res.status).toBe(200);
-    expect(res.body.message).toBe('Login successful');
-    expect(res.body.user.email).toBe('test@example.com');
+    it('should not set Access-Control-Allow-Origin for an unlisted origin', async () => {
+      const res = await request(app)
+        .get('/auth/logout')
+        .set('Origin', 'http://evil.example.com');
+
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('should respond to a preflight OPTIONS request from the allowed origin', async () => {
+      const res = await request(app)
+        .options('/auth/login')
+        .set('Origin', ALLOWED_ORIGIN)
+        .set('Access-Control-Request-Method', 'POST')
+        .set('Access-Control-Request-Headers', 'Content-Type');
+
+      expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
+      expect(res.headers['access-control-allow-credentials']).toBe('true');
+      // 204 is the standard success status for preflight responses.
+      expect([200, 204]).toContain(res.status);
+    });
+
+    it('should include CORS headers on a credentialed login request from the allowed origin', async () => {
+      await User.create({
+        username: 'corsuser',
+        email: 'cors@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      const res = await request(app)
+        .post('/auth/login')
+        .set('Origin', ALLOWED_ORIGIN)
+        .send({ email: 'cors@example.com', password: VALID_PASSWORD });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
+      expect(res.headers['access-control-allow-credentials']).toBe('true');
+    });
   });
 
-  it('should not login a user with wrong password', async () => {
-    await User.create({
-      username: 'testuser',
-      email: 'test@example.com',
-      password: 'password123',
+  // ---------------- SESSION COOKIE FLAGS ----------------
+  describe('Session cookie security flags', () => {
+    it('should set HttpOnly on the session cookie after login', async () => {
+      await User.create({
+        username: 'cookieuser',
+        email: 'cookie@example.com',
+        password: VALID_PASSWORD,
+      });
+
+      const res = await request(app)
+        .post('/auth/login')
+        .set('Origin', ALLOWED_ORIGIN)
+        .send({ email: 'cookie@example.com', password: VALID_PASSWORD });
+
+      expect(res.status).toBe(200);
+
+      const setCookie = res.headers['set-cookie'];
+      expect(setCookie).toBeTruthy();
+
+      const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+      expect(cookieStr).toMatch(/HttpOnly/i);
     });
 
-    const agent = request.agent(app);
+    it('should set SameSite=Strict on the session cookie after login', async () => {
+      await User.create({
+        username: 'samesiteuser',
+        email: 'samesite@example.com',
+        password: VALID_PASSWORD,
+      });
 
-    const res = await agent.post('/auth/login').send({
-      email: 'test@example.com',
-      password: 'wrongpassword',
+      const res = await request(app)
+        .post('/auth/login')
+        .set('Origin', ALLOWED_ORIGIN)
+        .send({ email: 'samesite@example.com', password: VALID_PASSWORD });
+
+      expect(res.status).toBe(200);
+
+      const setCookie = res.headers['set-cookie'];
+      expect(setCookie).toBeTruthy();
+
+      const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie;
+      expect(cookieStr).toMatch(/SameSite=Strict/i);
     });
+  });
+});
 
-    expect(res.status).toBe(401);
+// ---------------------------------------------------------------------------
+// Environment validation — pure unit tests, no MongoDB required.
+// ---------------------------------------------------------------------------
+describe('Environment validation (validateEnv)', () => {
+  let savedNodeEnv;
+  let savedFrontendOrigin;
+  let hadFrontendOrigin;
+
+  beforeEach(() => {
+    savedNodeEnv = process.env.NODE_ENV;
+    hadFrontendOrigin = Object.prototype.hasOwnProperty.call(process.env, 'FRONTEND_ORIGIN');
+    savedFrontendOrigin = process.env.FRONTEND_ORIGIN;
   });
 
-  // ---------------- LOGOUT ----------------
-  it('should logout a logged-in user', async () => {
-    const agent = request.agent(app);
+  afterEach(() => {
+    process.env.NODE_ENV = savedNodeEnv;
+    if (hadFrontendOrigin) {
+      process.env.FRONTEND_ORIGIN = savedFrontendOrigin;
+    } else {
+      delete process.env.FRONTEND_ORIGIN;
+    }
+  });
 
-    await agent.post('/auth/signup').send({
-      username: 'testuser',
-      email: 'test@example.com',
-      password: 'password123',
-    });
+  it('should throw when FRONTEND_ORIGIN is absent in production', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.FRONTEND_ORIGIN;
 
-    await agent.post('/auth/login').send({
-      email: 'test@example.com',
-      password: 'password123',
-    });
+    expect(() => validateEnv()).toThrow();
+  });
 
-    const res = await agent.get('/auth/logout');
+  it('should include FRONTEND_ORIGIN in the error message when throwing in production', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.FRONTEND_ORIGIN;
 
-    expect(res.status).toBe(200);
-    expect(res.body.message).toBe('Logged out successfully');
+    expect(() => validateEnv()).toThrowError(/FRONTEND_ORIGIN/);
+  });
+
+  it('should not throw when FRONTEND_ORIGIN is set in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.FRONTEND_ORIGIN = 'https://app.example.com';
+
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  it('should not throw in development without FRONTEND_ORIGIN', () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.FRONTEND_ORIGIN;
+
+    expect(() => validateEnv()).not.toThrow();
+  });
+
+  it('should not throw in test environment without FRONTEND_ORIGIN', () => {
+    process.env.NODE_ENV = 'test';
+    delete process.env.FRONTEND_ORIGIN;
+
+    expect(() => validateEnv()).not.toThrow();
   });
 });

--- a/spec/user.model.spec.cjs
+++ b/spec/user.model.spec.cjs
@@ -1,5 +1,12 @@
-const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
+
+// Resolve mongoose from the backend directory so this test and the User model
+// share one mongoose instance, avoiding connection-state mismatches when
+// backend/node_modules is present alongside the root node_modules.
+const mongoose = require(
+  require.resolve('mongoose', { paths: [`${__dirname}/../backend`] })
+);
+
 const User = require('../backend/models/User');
 
 describe('User Model', () => {

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -30,7 +30,9 @@ const Login: React.FC = () => {
     setIsLoading(true);
 
     try {
-      const response = await axios.post(`${backendUrl}/api/auth/login`, formData);
+      const response = await axios.post(`${backendUrl}/api/auth/login`, formData, {
+        withCredentials: true,
+      });
       setMessage(response.data.message);
 
       if (response.data.message === 'Login successful') {

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -83,9 +83,9 @@ const SignUp: React.FC = () => {
     }
     setIsLoading(true);
     try {
-      const response = await axios.post(`${backendUrl}/api/auth/signup`,
-        formData // Include cookies for session
-      );
+      const response = await axios.post(`${backendUrl}/api/auth/signup`, formData, {
+        withCredentials: true,
+      });
       setMessage(response.data.message); // Show success message from backend
 
       // Navigate to login page after successful signup


### PR DESCRIPTION
## Closes

Closes #454

---

## Problem

`backend/server.js` applied `cors('*')`, which:

1. **Sent `Access-Control-Allow-Origin: *` on every response** — including authenticated endpoints — making it impossible to attach session cookies to cross-origin requests (browsers refuse `credentials` with a wildcard ACAO).
2. **Left the session cookie without `SameSite`, `Secure`, or explicit `HttpOnly` attributes** — cookie transmitted in plaintext over HTTP and vulnerable to CSRF via cross-site navigations.
3. **Had no startup guard** — a missing `FRONTEND_ORIGIN` in production would silently degrade to an open wildcard, with no operator-visible error.

---

## Changes

### `backend/config/validateEnv.js` *(new)*
Extracts startup environment validation into a standalone, unit-testable module. In production the server calls `process.exit(1)` with a clear error if `FRONTEND_ORIGIN` is unset; in development it defaults to `http://localhost:5173` and logs a warning.

### `backend/server.js`
- Replaces `cors('*')` with a **function-based origin allowlist** driven by `FRONTEND_ORIGIN`.  
  A string value in the `cors` `origin` option sends the header unconditionally; a function is required to suppress the header entirely for unlisted origins.
- Adds `credentials: true` so the browser sends the session cookie on cross-origin requests.
- Adds `httpOnly: true`, `secure` (production-only), and `sameSite: 'strict'` to the session cookie.

### `src/pages/Login/Login.tsx` · `src/pages/Signup/Signup.tsx`
- Adds `withCredentials: true` to both Axios calls so the browser attaches and stores the session cookie for cross-origin requests.

### `spec/auth.routes.spec.cjs`
- Restructures the existing tests under a single outer `describe` to avoid Mongoose connection conflicts with Jasmine's random seed ordering.
- Resolves `mongoose`, `passport`, and `express-session` from the backend directory so the test app and the application code share one module instance (prevents operation-buffering timeouts when `backend/node_modules` exists).
- Adds **CORS behaviour** suite: allowed origin reflected, disallowed origin absent, preflight, credentialed login.
- Adds **Session cookie security flags** suite: `HttpOnly` and `SameSite=Strict` assertions.
- Adds **Environment validation** suite: production throws without `FRONTEND_ORIGIN`, non-production does not.
- Updates test passwords to satisfy the `signupSchema` Zod regex so signup and logout route tests exercise the full validation path.

### `spec/user.model.spec.cjs`
- Applies the same `require.resolve` fix so the User model tests share the backend's mongoose instance.

### `backend/.env.example` · `.env.example` *(new)*
Documents all required environment variables, including `FRONTEND_ORIGIN`.

### `README.md`
Adds an Environment Variables table to the setup guide.

---

## New environment variable

| Variable | Required | Dev default | Description |
|---|---|---|---|
| `FRONTEND_ORIGIN` | **Yes in production** | `http://localhost:5173` | Exact URL of the frontend; restricts the CORS allowlist |

---

## Test results

```
20 specs, 0 failures   (Jasmine, randomised seed)
```

---

## Behaviour preserved

- Login, signup, and logout API contracts unchanged.
- Session semantics and Passport authentication flow unchanged.
- Development workflow requires no additional setup — `FRONTEND_ORIGIN` defaults automatically.

---

## Test plan

- [ ] Copy `backend/.env.example` → `backend/.env`; set `FRONTEND_ORIGIN=http://localhost:5173`; confirm server starts.
- [ ] Log in from the frontend; confirm the response sets a cookie with `HttpOnly; SameSite=Strict`.
- [ ] Send a request with `Origin: http://evil.example.com`; confirm no `Access-Control-Allow-Origin` header in the response.
- [ ] Remove `FRONTEND_ORIGIN`, set `NODE_ENV=production`; confirm the server refuses to start.
- [ ] Run `npm run test:backend` — all 20 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Setup guide now includes environment variable configuration instructions with required variables documented.

* **Security**
  * CORS now restricted to configured frontend origin instead of allowing all requests.
  * Session cookies hardened with HttpOnly and SameSite security flags.
  * Login and signup now properly support session-based authentication with credential transmission.

* **Tests**
  * Added comprehensive authentication tests including CORS header and session security validation.

* **Chores**
  * Added testing and HTTP request testing dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->