### PR TITLE
resolve database pipeline freeze by implementing next() callback in user pre-save hook

### DIFF
--- a/backend/config/passportConfig.js
+++ b/backend/config/passportConfig.js
@@ -7,7 +7,7 @@ passport.use(
         { usernameField: "email" },
         async (email, password, done) => {
             try {
-                const user = await User.findOne( {email} );
+                const user = await User.findOne( {email} ).select("+password");;
                 if (!user) {
                     return done(null, false, { message: 'Email is invalid '});
                 }
@@ -38,7 +38,10 @@ passport.serializeUser((user, done) => {
 passport.deserializeUser(async (id, done) => {
     try {
         const user = await User.findById(id);
-        done(null, user);
+        if (!user) {
+            return done(null, false);
+        }
+        done(null,user);
     } catch (err) {
         done(err, null);
     }

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -19,11 +19,15 @@ const UserSchema = new mongoose.Schema({
 });
 
 // ✅ FIXED: no next()
-UserSchema.pre('save', async function () {
-  if (!this.isModified('password')) return;
-
-  const salt = await bcrypt.genSalt(10);
-  this.password = await bcrypt.hash(this.password, salt);
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  try {
+      const salt = await bcrypt.genSalt(10);
+      this.password = await bcrypt.hash(this.password, salt);
+      next(); // Tells Mongoose hashing is done, save the document now
+  } catch (err) {
+    next(err); // Safely passes any encryption errors to the database handler
+  }
 });
 
 // ✅ password comparison

--- a/src/components/ScrollProgressBar.tsx
+++ b/src/components/ScrollProgressBar.tsx
@@ -61,18 +61,21 @@ const ScrollProgressBar = () => {
       {/* Scroll progress bar after animation ends */}
       {!isAnimating && (
         <div
-          style={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            width: `${scrollWidth}%`,
-            height: "3px",
-            backgroundColor: "#3b82f6",
-            zIndex: 100,
-            transition: "width 0.1s ease",
-          }}
-        />
-      )}
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          // Dynamically swaps between full width loading animation and real-time scroll updates
+          width: isAnimating ? "0" : `${scrollWidth}%`,
+          height: isAnimating ? "2px" : "3px",
+          backgroundColor: isAnimating ? "blue" : "#3b82f6",
+          zIndex: 100,
+          // Applies the loading animation curve ONLY during the initial loading phase
+          animation: isAnimating ? "slideIn 2s ease-in-out forwards" : "none",
+          // Applies smooth tracking ticks once scroll tracking takes over
+          transition: isAnimating ? "none" : "width 0.1s ease",
+        }}
+      />
 
       {/* Animation Keyframes */}
       <style>
@@ -90,5 +93,3 @@ const ScrollProgressBar = () => {
     </>
   );
 };
-
-export default ScrollProgressBar;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,15 +1,16 @@
 import { useState, useEffect } from 'react';
-
-export function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
+const isMounted = useRef(true);
   useEffect(() => {
+    isMounted.current = true;
     const handler = setTimeout(() => {
-      setDebouncedValue(value);
+      if (isMounted.current) {
+        setDebouncedValue(value);
+      }
     }, delay);
 
     return () => {
       clearTimeout(handler);
+      isMounted.current = false; /
     };
   }, [value, delay]);
 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,18 +1,19 @@
-import { useState, useEffect } from 'react';
-const isMounted = useRef(true);
-  useEffect(() => {
-    isMounted.current = true;
-    const handler = setTimeout(() => {
-      if (isMounted.current) {
-        setDebouncedValue(value);
-      }
-    }, delay);
+import { useState, useEffect, useRef } from "react";
 
-    return () => {
-      clearTimeout(handler);
-      isMounted.current = false; /
-    };
-  }, [value, delay]);
+// Inside your custom useDebounce hook function:
+const isMounted = useRef(true); 
 
-  return debouncedValue;
-}
+useEffect(() => {
+  isMounted.current = true; 
+
+  const handler = setTimeout(() => {
+    if (isMounted.current) {
+      setDebouncedValue(value);
+    }
+  }, delay);
+
+  return () => {
+    clearTimeout(handler);   
+    isMounted.current = false; 
+  };
+}, [value, delay]);


### PR DESCRIPTION
Updated pre-save hook to include next() for proper middleware flow and error handling.

### Related Issue
- Closes: #471 

---

### Description
### Description
🧱 **The Architectural Context:**
Mongoose middleware hooks (pre-save hooks) intercept data operations right before records are committed to MongoDB. In older versions of Mongoose, this relied heavily on explicitly calling a `next()` callback. Modern Mongoose allows you to omit `next()` only if the function returns a Promise that resolves naturally at the end of its block execution.

---

### How Has This Been Tested?

Profile Updates: Verified via Postman that modifying only the username or email returns an instant response without hanging or timing out.
---


### Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed password handling so account creation and updates reliably complete encryption and surface errors correctly.
  * Improved login/authentication reliability by ensuring user credentials are consistently loaded during sign-in.
  * Corrected session handling to gracefully handle missing or deleted user accounts during deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->