### PR TITLE
fix(contributor-profile): prevent crashes on failed GitHub API responses

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -26,14 +26,28 @@ export default function ContributorProfile() {
 
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
+        if (!userRes.ok) {
+          if (userRes.status === 404) {
+            setProfile(null);
+            setPRs([]);
+            return;
+          }
+          throw new Error(`Failed to load user (${userRes.status})`);
+        }
         const userData = await userRes.json();
-        setProfile(userData);
+        setProfile(userData as Profile);
 
         const prsRes = await fetch(
           `https://api.github.com/search/issues?q=author:${username}+type:pr`
         );
-        const prsData = await prsRes.json();
-        setPRs(prsData.items);
+        if (!prsRes.ok) {
+          // avoid crashing — show empty PR list and notify user
+          setPRs([]);
+          toast.error("Failed to load pull requests.");
+        } else {
+          const prsData = await prsRes.json();
+          setPRs(prsData.items ?? []);
+        }
       } catch {
         toast.error("Failed to fetch user data.");
       } finally {


### PR DESCRIPTION
### Related Issue
- Closes: #461

---

### Description

This PR fixes the contributor profile page crashing when GitHub API requests fail.

### Changes made:
- Added proper `response.ok` checks for GitHub API responses
- Prevented crashes when GitHub rate limits API requests
- Added safe fallback using `prsData.items ?? []`
- Handled invalid GitHub usernames gracefully
- Added toast error messages for failed API responses

This ensures the page no longer crashes and users receive proper feedback when API requests fail.

---

### How Has This Been Tested?

- Tested with valid GitHub usernames
- Tested with invalid usernames
- Tested API failure handling manually
- Verified the page no longer crashes when PR data is unavailable

---

### Screenshots (if applicable)

N/A — Backend/API handling fix, no major UI changes.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing contributor profiles, now gracefully showing an empty state instead of crashing.
  * Pull request loading failures now display error notifications without disrupting the app.
  * Enhanced data validation to prevent crashes from unexpected response formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->