### PR TITLE
Fix passport auth

### DIFF
--- a/backend/config/passportConfig.js
+++ b/backend/config/passportConfig.js
@@ -7,7 +7,7 @@ passport.use(
         { usernameField: "email" },
         async (email, password, done) => {
             try {
-                const user = await User.findOne( {email} );
+                const user = await User.findOne( {email} ).select("+password");;
                 if (!user) {
                     return done(null, false, { message: 'Email is invalid '});
                 }
@@ -38,7 +38,10 @@ passport.serializeUser((user, done) => {
 passport.deserializeUser(async (id, done) => {
     try {
         const user = await User.findById(id);
-        done(null, user);
+        if (!user) {
+            return done(null, false);
+        }
+        done(null,user);
     } catch (err) {
         done(err, null);
     }

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -19,11 +19,15 @@ const UserSchema = new mongoose.Schema({
 });
 
 // ✅ FIXED: no next()
-UserSchema.pre('save', async function () {
-  if (!this.isModified('password')) return;
-
-  const salt = await bcrypt.genSalt(10);
-  this.password = await bcrypt.hash(this.password, salt);
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  try {
+      const salt = await bcrypt.genSalt(10);
+      this.password = await bcrypt.hash(this.password, salt);
+      next(); // Tells Mongoose hashing is done, save the document now
+  } catch (err) {
+    next(err); // Safely passes any encryption errors to the database handler
+  }
 });
 
 // ✅ password comparison


### PR DESCRIPTION
### Related Issue
- Closes: #472

---

### Description
*The Architectural Context:**
Security best practices dictate that sensitive fields like passwords should be excluded from standard database query responses to prevent accidental exposure down the network line (e.g., logging or sending data payloads back to the frontend UI). This is handled via Mongoose's field selection control (`select: false`).

---


### Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update
