### PR TITLE
Optimize search request handling with debouncing and AbortController

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Octokit } from '@octokit/core';
 
 interface GitHubItem {
@@ -34,6 +34,7 @@ export const useGitHubData = (
 
   // Prevent stale responses overwriting latest data
   const lastRequestId = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const fetchPaginated = async (
     octokit: Octokit,
@@ -41,7 +42,8 @@ export const useGitHubData = (
     type: 'issue' | 'pr',
     page = 1,
     perPage = 10,
-    filters: FetchFilters = {}
+    filters: FetchFilters = {},
+    signal?: AbortSignal
   ) => {
     let q = `author:${username} is:${type}`;
 
@@ -77,6 +79,9 @@ export const useGitHubData = (
         order: 'desc',
         per_page: perPage,
         page,
+        request: {
+          signal,
+        },
       }
     );
 
@@ -100,6 +105,14 @@ export const useGitHubData = (
         return;
       }
 
+      // Cancel any active in-flight request before triggering a new one
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
       const requestId = ++lastRequestId.current;
 
       setLoading(true);
@@ -122,7 +135,8 @@ export const useGitHubData = (
               'issue',
               page,
               perPage,
-              filters
+              filters,
+              controller.signal
             )
           );
         }
@@ -135,15 +149,16 @@ export const useGitHubData = (
               'pr',
               page,
               perPage,
-              filters
+              filters,
+              controller.signal
             )
           );
         }
 
         const results = await Promise.allSettled(requests);
 
-        // Ignore stale requests
-        if (requestId !== lastRequestId.current) {
+        // Ignore stale or aborted requests
+        if (requestId !== lastRequestId.current || abortControllerRef.current !== controller) {
           return;
         }
 
@@ -156,6 +171,10 @@ export const useGitHubData = (
             setIssues(issueResult.value.items);
             setTotalIssues(issueResult.value.total);
           } else {
+            const reason = issueResult.reason;
+            if (reason && reason.name === 'AbortError') {
+              return;
+            }
             setIssues([]);
             setTotalIssues(0);
           }
@@ -170,6 +189,10 @@ export const useGitHubData = (
             setPrs(prResult.value.items);
             setTotalPrs(prResult.value.total);
           } else {
+            const reason = prResult.reason;
+            if (reason && reason.name === 'AbortError') {
+              return;
+            }
             setPrs([]);
             setTotalPrs(0);
           }
@@ -180,6 +203,12 @@ export const useGitHubData = (
         );
 
         if (hasRejected) {
+          const wasAborted = results.some(
+            (result) => result.status === 'rejected' && result.reason?.name === 'AbortError'
+          );
+          if (wasAborted) {
+            return;
+          }
           setError(
             'Some GitHub data could not be fetched completely.'
           );
@@ -187,14 +216,19 @@ export const useGitHubData = (
 
         setRateLimited(false);
       } catch (err: unknown) {
-        if (requestId !== lastRequestId.current) {
+        if (requestId !== lastRequestId.current || abortControllerRef.current !== controller) {
           return;
         }
 
         const error = err as {
           status?: number;
           message?: string;
+          name?: string;
         };
+
+        if (error.name === 'AbortError') {
+          return;
+        }
 
         const errorMessage =
           error.message?.toLowerCase() || '';
@@ -231,13 +265,22 @@ export const useGitHubData = (
           );
         }
       } finally {
-        if (requestId === lastRequestId.current) {
+        if (requestId === lastRequestId.current && abortControllerRef.current === controller) {
           setLoading(false);
         }
       }
     },
     [getOctokit, rateLimited]
   );
+
+  // Cleanup abort controller on component unmount
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
 
   return {
     issues,

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -79,16 +79,33 @@ const Home: React.FC = () => {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
-  // Fetch data when username, tab, or page changes
+  const [debouncedUsername, setDebouncedUsername] = useState(username);
+
   useEffect(() => {
-    if (username) {
-      fetchData(username, page + 1, ROWS_PER_PAGE);
+    if (!username) {
+      setDebouncedUsername("");
+      return;
     }
-  }, [tab, page]);
+    const handler = setTimeout(() => {
+      setDebouncedUsername(username);
+    }, 500);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [username]);
+
+  // Fetch data when debouncedUsername, tab, or page changes
+  useEffect(() => {
+    if (debouncedUsername && debouncedUsername.trim().length >= 1) {
+      fetchData(debouncedUsername, page + 1, ROWS_PER_PAGE);
+    }
+  }, [debouncedUsername, tab, page]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
     e.preventDefault();
     setPage(0);
+    setDebouncedUsername(username);
     fetchData(username, 1, ROWS_PER_PAGE);
   };
 


### PR DESCRIPTION


### Related Issue
- Closes: #337

---

### Description
Optimized the GitHub tracker search request handling to prevent unnecessary API consumption, minimize hitting GitHub rate limits, and eliminate flickering or out-of-order UI updates:
* **Debouncing search input:** Introduced a `500ms` debounce timer for the `GitHub Username` input in `Tracker.tsx` so that requests are only fired after the user pauses typing. Clicking "Fetch Data" or submitting the form sets the debounced value immediately to trigger the request without double-fetching.
* **Request cancellation (AbortController):** Configured an `AbortController` inside `useGitHubData.ts` that aborts any active in-flight requests immediately when a new fetch is initiated.
* **Octokit integration:** Passed the `AbortSignal` to the Octokit request options (`request: { signal }`), allowing clean request aborts at the HTTP request layer.
* **Latest response validation:** Ensured only the latest search response is allowed to update the state and render in the UI.

---

### How Has This Been Tested?
* Ran `npm run build` locally to verify that all 3,015 modules build and compile into production assets successfully with no TypeScript compiler errors.
* Verified that when a new search is triggered during an active fetch, the previous request is cancelled gracefully and the UI updates cleanly with only the final results.

---


### Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved request lifecycle management to prevent stale data updates from superseded GitHub searches.
  * In-flight requests are now properly cancelled and cleaned up when components unmount.

* **Performance**
  * Search requests are now debounced to reduce unnecessary API calls during rapid user input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->