### PR TITLE
Add GitHub API rate limit handling UI

### DIFF
--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -12,6 +12,7 @@ interface EventType {
 export default function ActivityFeed({ username }: { username: string }) {
   const [events, setEvents] = useState<EventType[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
 
   // 🕒 time ago function
   const getTimeAgo = (dateString: string) => {
@@ -27,20 +28,53 @@ export default function ActivityFeed({ username }: { username: string }) {
 
   useEffect(() => {
     const fetchEvents = async () => {
-      try {
-        setLoading(true);
+        try {
+          setLoading(true);
+          setError("");
 
-        const res = await fetch(
-          `https://api.github.com/users/${username}/events`
-        );
-        const data = await res.json();
+          const res = await fetch(
+            `https://api.github.com/users/${username}/events`
+          );
 
-        setEvents(data);
-        setLoading(false);
-      } catch (err) {
-        console.error(err);
-        setLoading(false);
-      }
+          //  Handle GitHub API rate limit
+          if (res.status === 403) {
+            const remaining =
+              res.headers.get("X-RateLimit-Remaining") || "0";
+
+            const reset =
+              res.headers.get("X-RateLimit-Reset");
+
+            const resetTime = reset
+              ? new Date(Number(reset) * 1000).toLocaleTimeString()
+              : "Unknown";
+
+            setError(
+              `GitHub API rate limit exceeded.
+               Please try again after ${resetTime}.
+               Remaining Requests: ${remaining}`
+            );
+
+            setEvents([]);
+            setLoading(false);
+            return;
+          }
+
+          if (!res.ok) {
+            throw new Error("Failed to fetch activity");
+          }
+
+          const data = await res.json();
+
+          setEvents(data);
+        } catch (err) {
+          console.error(err);
+
+          setError(
+            "Something went wrong while fetching GitHub activity."
+          );
+        } finally {
+          setLoading(false);
+        }
     };
 
     fetchEvents();
@@ -51,14 +85,21 @@ export default function ActivityFeed({ username }: { username: string }) {
 
   return (
     <div className="p-4">
-      <h2 className="text-xl font-bold mb-4 text-center">
+      <h2 className="text-xl font-bold mb-4 text-center text-black dark:text-white">
         Activity Feed
       </h2>
+      
+      {error && (
+        <div className="bg-yellow-100 dark:bg-yellow-900 border border-yellow-400 text-yellow-800 dark:text-yellow-200 px-4 py-3 rounded mb-4">
+          {error}
+        </div>
+      )}
+
 
       {loading ? (
         <p className="text-center">Loading...</p>
       ) : events.length === 0 ? (
-        <p className="text-center">No activity found</p>
+        <p className="text-center text-black dark:text-white">No activity found</p>
       ) : (
         events.slice(0, 10).map((event) => (
           <div

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -3,7 +3,7 @@ export default function Activity() {
   return (
     <div className="w-full h-full p-6 bg-gray-50 dark:bg-gray-800">
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4 text-center">
+        <h1 className="text-2xl font-bold mb-4 text-center text-black dark:text-white">
           Live GitHub Activity
         </h1>
 


### PR DESCRIPTION
### Related Issue
- Closes: #496 

---

### Description

Implemented GitHub API rate limit handling in the Activity Feed component.

### Changes Made
- Added handling for GitHub API rate limit errors (`403`)
- Displayed reset time using `X-RateLimit-Reset`
- Displayed remaining request count using `X-RateLimit-Remaining`
- Added proper error state handling
- Improved loading and empty state handling
- Fixed dark mode text visibility issues
- Added responsive error alert UI for both light and dark themes

---

### How Has This Been Tested?

- Tested API success response
- Tested GitHub API rate limit exceeded response
- Verified reset time rendering
- Verified remaining request count rendering
- Verified loading state functionality
- Verified empty state rendering
- Tested in both light mode and dark mode
- Tested responsive UI behavior

---

### Screenshots (if applicable)

- Added screenshots showing:
  - Rate limit exceeded alert
  - Dark mode UI
  - Light mode UI
  - Activity Feed rendering

---

### Type of Change

- [x] Bug fix
- [x] New feature
- [x] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for GitHub API rate limit responses with reset time display.
  * Improved handling of failed API requests with user-friendly error messages.

* **UI/Style**
  * Added error banner to display API errors.
  * Enhanced dark mode support for page headings and activity feed text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->