### PR TITLE
Fix 550

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
@@ -14,14 +13,13 @@
     "docker:dev": "docker compose --profile dev up --build",
     "docker:prod": "docker compose --profile prod up -d --build"
   },
-
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@primer/octicons-react": "^19.25.0",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^6.0.2",
     "axios": "^1.7.7",
     "express": "^5.2.1",
     "framer-motion": "^12.23.12",
@@ -37,7 +35,6 @@
     "recharts": "^3.8.1",
     "tailwindcss": "^3.4.14"
   },
-
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -50,33 +47,22 @@
     "@types/react-redux": "^7.1.34",
     "@types/react-router-dom": "^5.3.3",
 
-    "@vitejs/plugin-react-swc": "^3.5.0",
-
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.3",
-
     "eslint": "^9.13.0",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
-
     "express-session": "^1.18.2",
-
     "globals": "^15.11.0",
-
     "jasmine": "^5.13.0",
     "jasmine-spec-reporter": "^7.0.0",
-
     "jsdom": "^29.1.1",
-
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
-
     "supertest": "^7.2.2",
-
     "typescript-eslint": "^8.59.3",
-
-    "vite": "^5.4.10",
+    "vite": "^8.0.14",
     "vitest": "^4.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@primer/octicons-react": "^19.25.0",
-    "@vitejs/plugin-react": "^6.0.2",
     "axios": "^1.7.7",
     "express": "^5.2.1",
     "framer-motion": "^12.23.12",
@@ -63,6 +62,7 @@
     "supertest": "^7.2.2",
     "typescript-eslint": "^8.59.3",
     "vite": "^8.0.14",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "@vitejs/plugin-react": "^6.0.2"
   }
 }

--- a/src/pages/Signup/Signup.tsx
+++ b/src/pages/Signup/Signup.tsx
@@ -223,7 +223,11 @@ const SignUp: React.FC = () => {
                 placeholder="Enter your username"
                 value={formData.username}
                 onChange={handleChange}
-                className="w-full px-4 py-4 rounded-2xl border"
+                className={`w-full px-4 py-4 rounded-2xl border focus:outline-none transition-all ${
+                  mode === "dark"
+                    ? "bg-white/5 border-white/10 text-white placeholder-slate-400 focus:ring-2 focus:ring-purple-500"
+                    : "bg-gray-100 border-gray-300 text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-purple-400"
+                }`}
               />
               {errors.username && (
                 <p className="text-red-500 text-sm mt-2">{errors.username}</p>
@@ -238,7 +242,11 @@ const SignUp: React.FC = () => {
                 placeholder="Enter your email"
                 value={formData.email}
                 onChange={handleChange}
-                className="w-full px-4 py-4 rounded-2xl border"
+                className={`w-full px-4 py-4 rounded-2xl border focus:outline-none transition-all ${
+                  mode === "dark"
+                    ? "bg-white/5 border-white/10 text-white placeholder-slate-400 focus:ring-2 focus:ring-purple-500"
+                    : "bg-gray-100 border-gray-300 text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-purple-400"
+                }`}
               />
               {errors.email && (
                 <p className="text-red-500 text-sm mt-2">{errors.email}</p>
@@ -253,7 +261,11 @@ const SignUp: React.FC = () => {
                 placeholder="Enter your password"
                 value={formData.password}
                 onChange={handleChange}
-                className="w-full px-4 py-4 rounded-2xl border"
+                className={`w-full px-4 py-4 rounded-2xl border focus:outline-none transition-all ${
+                  mode === "dark"
+                    ? "bg-white/5 border-white/10 text-white placeholder-slate-400 focus:ring-2 focus:ring-purple-500"
+                    : "bg-gray-100 border-gray-300 text-gray-900 placeholder-gray-500 focus:ring-2 focus:ring-purple-400"
+                }`}
               />
               {errors.password && (
                 <p className="text-red-500 text-sm mt-2">{errors.password}</p>


### PR DESCRIPTION
### Related Issue
- Closes: #550 
---
### Description
**What was causing the issue?** 

The input fields on the **_Signup component_** lacked explicit styling for text and background color. Since the container applies a **text-white** or **text-black** depending on dark/light mode and Tailwind removes default input background colors, the typed text was rendering as white on a white/transparent background, making it "invisible." Browser autofill overrides this behavior which is why autofill was working perfectly.

The Fix: 

I have applied the dynamic Tailwind CSS classes to the **three input fields on Signup.tsx** to explicitly set the text color, background color, and _focus outline to exactly match how they were correctly styled on the Login page:_

> Light Mode: Gray background (bg-gray-100), dark gray text (text-gray-900), and a purple focus ring.
> Dark Mode: Semi-transparent white background (bg-white/5), white text (text-white), and a purple focus ring.

---

### How Has This Been Tested?
Tested locally in the Edge browser environment

---
### Before

<img width="1707" height="1319" alt="t4" src="https://github.com/user-attachments/assets/bb20e6a4-41da-4efa-94e4-1b33047e49b8" />


### Video of the fixed Signup form

https://github.com/user-attachments/assets/e4f4ab88-2587-449b-b45a-e1c8dcaf91b9

---

### Type of Change
- Bug fix

Additional Changes:
- Updated Vite and @vitejs/plugin-react versions for local environment compatibility
- Removed outdated dependency versions causing peer dependency conflicts during development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Moved a build plugin to dev dependencies and upgraded it for improved development build compatibility.
  * Updated the build tool to a newer major version to align with tooling improvements and performance.
  * Removed an unused build plugin.
  * No changes to runtime scripts or user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->