### PR TITLE
fix(session): persist production sessions with Mongo-backed session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ $ npm i
 $ npm start
 ```
 
+### Backend Environment Variables
+
+Create `backend/.env` for local backend runs:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `MONGO_URI` | Yes | MongoDB connection string used by Mongoose and the persistent session store |
+| `SESSION_SECRET` | Yes | Secret used to sign Express session cookies |
+| `NODE_ENV` | No | Set to `production` to send session cookies only over HTTPS |
+
 ## 🧪 Backend Unit & Integration Testing with Jasmine
 
 This project uses the Jasmine framework for backend unit and integration tests. The tests cover:

--- a/backend/config/session.js
+++ b/backend/config/session.js
@@ -1,0 +1,32 @@
+const MongoStore = require('connect-mongo');
+
+const SESSION_TTL_SECONDS = 14 * 24 * 60 * 60;
+
+function createSessionConfig({
+  mongoUrl = process.env.MONGO_URI,
+  sessionSecret = process.env.SESSION_SECRET,
+  nodeEnv = process.env.NODE_ENV,
+  storeFactory = MongoStore,
+} = {}) {
+  if (!mongoUrl) {
+    throw new Error('MONGO_URI is required to configure the session store');
+  }
+
+  return {
+    secret: sessionSecret,
+    resave: false,
+    saveUninitialized: false,
+    store: storeFactory.create({
+      mongoUrl,
+      ttl: SESSION_TTL_SECONDS,
+    }),
+    cookie: {
+      secure: nodeEnv === 'production',
+    },
+  };
+}
+
+module.exports = {
+  SESSION_TTL_SECONDS,
+  createSessionConfig,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.3",
+    "connect-mongo": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ const passport = require('passport');
 const bodyParser = require('body-parser');
 require('dotenv').config();
 const cors = require('cors');
+const { createSessionConfig } = require('./config/session');
 
 // Passport configuration
 require('./config/passportConfig');
@@ -28,11 +29,10 @@ app.use(cors({
 
 // Middleware
 app.use(bodyParser.json());
-app.use(session({
-    secret: process.env.SESSION_SECRET,
-    resave: false,
-    saveUninitialized: false,
-}));
+if (process.env.NODE_ENV === 'production') {
+    app.set('trust proxy', 1);
+}
+app.use(session(createSessionConfig()));
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@primer/octicons-react": "^19.25.0",
     "@vitejs/plugin-react": "^4.3.3",
     "axios": "^1.7.7",
+    "connect-mongo": "^5.1.0",
     "express": "^5.2.1",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.525.0",

--- a/spec/session.config.spec.cjs
+++ b/spec/session.config.spec.cjs
@@ -1,0 +1,115 @@
+const express = require('express');
+const request = require('supertest');
+const session = require('express-session');
+
+const { SESSION_TTL_SECONDS, createSessionConfig } = require('../backend/config/session');
+
+class TestSessionStore extends session.Store {
+  constructor() {
+    super();
+    this.sessions = new Map();
+  }
+
+  get(sid, callback) {
+    const sessionData = this.sessions.get(sid);
+    callback(null, sessionData ? JSON.parse(sessionData) : null);
+  }
+
+  set(sid, sessionData, callback) {
+    this.sessions.set(sid, JSON.stringify(sessionData));
+    callback(null);
+  }
+
+  destroy(sid, callback) {
+    this.sessions.delete(sid);
+    callback(null);
+  }
+}
+
+function createStoreFactory(store = new TestSessionStore()) {
+  const calls = [];
+
+  return {
+    calls,
+    store,
+    create(options) {
+      calls.push(options);
+      return store;
+    },
+  };
+}
+
+describe('Session configuration', () => {
+  it('initializes connect-mongo with the configured Mongo URL and TTL', () => {
+    const storeFactory = createStoreFactory();
+
+    const config = createSessionConfig({
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      sessionSecret: 'test-secret',
+      storeFactory,
+    });
+
+    expect(storeFactory.calls).toEqual([{
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      ttl: SESSION_TTL_SECONDS,
+    }]);
+    expect(config.store).toBe(storeFactory.store);
+    expect(SESSION_TTL_SECONDS).toBe(14 * 24 * 60 * 60);
+  });
+
+  it('does not fall back to express-session MemoryStore', () => {
+    const config = createSessionConfig({
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      sessionSecret: 'test-secret',
+      storeFactory: createStoreFactory(),
+    });
+
+    expect(config.store).toBeDefined();
+    expect(config.store instanceof session.MemoryStore).toBeFalse();
+  });
+
+  it('uses secure cookies in production only', () => {
+    const productionConfig = createSessionConfig({
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      sessionSecret: 'test-secret',
+      nodeEnv: 'production',
+      storeFactory: createStoreFactory(),
+    });
+    const developmentConfig = createSessionConfig({
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      sessionSecret: 'test-secret',
+      nodeEnv: 'development',
+      storeFactory: createStoreFactory(),
+    });
+
+    expect(productionConfig.cookie.secure).toBeTrue();
+    expect(developmentConfig.cookie.secure).toBeFalse();
+  });
+
+  it('requires MongoDB configuration for persistent sessions', () => {
+    expect(() => createSessionConfig({
+      mongoUrl: '',
+      sessionSecret: 'test-secret',
+      storeFactory: createStoreFactory(),
+    })).toThrowError(/MONGO_URI/);
+  });
+
+  it('persists session data through the configured store', async () => {
+    const app = express();
+
+    app.use(session(createSessionConfig({
+      mongoUrl: 'mongodb://127.0.0.1:27017/github_tracker_test',
+      sessionSecret: 'test-secret',
+      storeFactory: createStoreFactory(),
+    })));
+    app.get('/count', (req, res) => {
+      req.session.views = (req.session.views || 0) + 1;
+      res.json({ views: req.session.views });
+    });
+
+    const agent = request.agent(app);
+
+    await agent.get('/count').expect(200, { views: 1 });
+    await agent.get('/count').expect(200, { views: 2 });
+  });
+});


### PR DESCRIPTION
Closes #453

## Summary

Replaces the default `express-session` `MemoryStore` fallback with a persistent Mongo-backed session store using `connect-mongo`.

The backend previously initialized `express-session` without a configured `store`, causing Express to silently fall back to the built-in in-memory `MemoryStore`, which is explicitly not production-safe.

This PR introduces durable Mongo-backed session persistence while preserving the existing session/auth behavior.

---

## Problems Fixed

The previous implementation caused:

- sessions to be lost on restart/deploy/crash
- memory growth under sustained traffic
- incompatibility with multi-instance deployments
- unstable authenticated user experience
- inability to scale safely behind load balancers

Because all sessions existed only in process memory.

---

## Implementation

Added shared session configuration using:

```js
MongoStore.create({
  mongoUrl: process.env.MONGO_URI,
  ttl: 14 * 24 * 60 * 60,
})
```

Key changes:

- replaced implicit `MemoryStore` fallback
- configured persistent Mongo-backed sessions
- added session TTL cleanup
- enabled production secure-cookie handling
- enabled trusted proxy handling for production deployments
- added fail-fast validation for missing `MONGO_URI`
- documented required session-related environment variables

Existing behavior preserved:

- `resave: false`
- `saveUninitialized: false`
- existing auth/session architecture
- existing session semantics

---

## Files Changed

- `backend/config/session.js`
- `backend/server.js`
- `backend/package.json`
- `package.json`
- `spec/session.config.spec.cjs`
- `README.md`

---

## Tests

Focused regression coverage added for:

- MongoStore initialization
- session TTL configuration
- production secure-cookie behavior
- no fallback to MemoryStore
- session persistence configuration correctness

### Verification

```bash
npx.cmd jasmine spec/session.config.spec.cjs
```

Result:

```txt
5 specs, 0 failures
```

Full backend suite was also attempted:

```bash
npm.cmd run test:backend
```

Existing unrelated MongoDB-dependent auth/model tests timed out locally, but all newly-added session persistence tests passed successfully.

---

## Notes

This PR intentionally keeps the scope limited to production session persistence and infrastructure hardening.

No JWT migration, auth architecture rewrite, or unrelated middleware refactors were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Backend Environment Variables section to guide local backend setup.

* **Improvements**
  * Enhanced session management with centralized configuration and MongoDB persistence.

* **Tests**
  * Added comprehensive test suite for session configuration and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->