### PR TITLE
fix(auth): add rate limiting for login and signup endpoints

### DIFF
--- a/backend/config/authRateLimit.js
+++ b/backend/config/authRateLimit.js
@@ -1,0 +1,25 @@
+const rateLimit = require('express-rate-limit');
+
+const AUTH_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const AUTH_RATE_LIMIT_MAX = 10;
+
+function createAuthRateLimiter(options = {}) {
+    return rateLimit({
+        windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+        max: AUTH_RATE_LIMIT_MAX,
+        standardHeaders: true,
+        legacyHeaders: false,
+        ...options,
+    });
+}
+
+const loginLimiter = createAuthRateLimiter();
+const signupLimiter = createAuthRateLimiter();
+
+module.exports = {
+    AUTH_RATE_LIMIT_MAX,
+    AUTH_RATE_LIMIT_WINDOW_MS,
+    createAuthRateLimiter,
+    loginLimiter,
+    signupLimiter,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
+    "express-rate-limit": "^7.5.0",
     "express-session": "^1.18.1",
     "mongoose": "^8.8.2",
     "passport": "^0.7.0",

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -7,6 +7,7 @@ const crypto = require("crypto");
 const User = require("../models/User");
 const { signupSchema, loginSchema } = require("../validators/authValidator");
 const { validateRequest } = require("../validators/validationRequest");
+const { loginLimiter, signupLimiter } = require("../config/authRateLimit");
 const router = express.Router();
 
 const getUseMongoAuth = () => typeof global.mongooseConnected !== "undefined" ? global.mongooseConnected : Boolean(process.env.MONGO_URI);
@@ -104,7 +105,7 @@ const createSessionUser = (req, user) => {
 };
 
 // Signup route
-router.post("/signup", validateRequest(signupSchema), async (req, res) => {
+router.post("/signup", signupLimiter, validateRequest(signupSchema), async (req, res) => {
 
     const { username,  email, password } = req.body;
 
@@ -164,7 +165,7 @@ router.get("/me", (req, res) => {
 });
 
 // Login route
-router.post("/login", validateRequest(loginSchema), async (req, res, next) => {
+router.post("/login", loginLimiter, validateRequest(loginSchema), async (req, res, next) => {
     if (!getUseMongoAuth()) {
         try {
             const { email, password } = req.body;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.7.7",
     "connect-mongo": "^5.1.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^7.5.0",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.525.0",
     "mongoose": "^9.6.2",

--- a/spec/auth.rate-limit.spec.cjs
+++ b/spec/auth.rate-limit.spec.cjs
@@ -1,0 +1,73 @@
+const express = require('express');
+const request = require('supertest');
+
+const {
+  AUTH_RATE_LIMIT_MAX,
+  AUTH_RATE_LIMIT_WINDOW_MS,
+  createAuthRateLimiter,
+} = require('../backend/config/authRateLimit');
+
+function createRateLimitedAuthApp(max = 2) {
+  const app = express();
+
+  app.use(express.json());
+  app.post('/api/auth/login', createAuthRateLimiter({ max }), (req, res) => {
+    res.status(200).json({ message: 'Login successful' });
+  });
+  app.post('/api/auth/signup', createAuthRateLimiter({ max }), (req, res) => {
+    res.status(201).json({ message: 'User created successfully' });
+  });
+
+  return app;
+}
+
+describe('Auth rate limiting', () => {
+  it('uses the configured production auth limiter baseline', () => {
+    expect(AUTH_RATE_LIMIT_MAX).toBe(10);
+    expect(AUTH_RATE_LIMIT_WINDOW_MS).toBe(15 * 60 * 1000);
+  });
+
+  it('allows legitimate login requests under the threshold', async () => {
+    const app = createRateLimitedAuthApp();
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@example.com', password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Login successful');
+  });
+
+  it('blocks excessive login requests with HTTP 429', async () => {
+    const app = createRateLimitedAuthApp();
+
+    await request(app).post('/api/auth/login').send({});
+    await request(app).post('/api/auth/login').send({});
+    const res = await request(app).post('/api/auth/login').send({});
+
+    expect(res.status).toBe(429);
+  });
+
+  it('blocks excessive signup requests with HTTP 429', async () => {
+    const app = createRateLimitedAuthApp();
+
+    await request(app).post('/api/auth/signup').send({});
+    await request(app).post('/api/auth/signup').send({});
+    const res = await request(app).post('/api/auth/signup').send({});
+
+    expect(res.status).toBe(429);
+  });
+
+  it('returns standard rate-limit headers without legacy headers', async () => {
+    const app = createRateLimitedAuthApp();
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@example.com', password: 'password123' });
+
+    expect(res.headers['ratelimit-limit']).toBeDefined();
+    expect(res.headers['ratelimit-remaining']).toBeDefined();
+    expect(res.headers['ratelimit-reset']).toBeDefined();
+    expect(res.headers['x-ratelimit-limit']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #452

## Summary

Adds focused authentication rate limiting for sensitive auth endpoints using `express-rate-limit`.

Previously, authentication endpoints had no throttling or abuse protection, allowing:

- unlimited credential stuffing attempts
- brute-force login attacks
- password spraying
- and bcrypt-driven CPU exhaustion attacks

Because every login request reached synchronous `bcryptjs` password verification with no request throttling.

This PR introduces scoped rate limiting for authentication-sensitive routes while preserving the existing auth/session behavior and response contracts.

---

## Implementation

Added `express-rate-limit` and configured dedicated auth limiters for:

- `POST /api/auth/login`
- `POST /api/auth/signup`

Limiter configuration:

```js
windowMs: 15 * 60 * 1000
max: 10
standardHeaders: true
legacyHeaders: false
```

Key changes:

- added auth-specific request throttling
- enabled standard rate-limit headers
- disabled legacy rate-limit headers
- preserved existing auth route behavior
- preserved existing login/signup response contracts
- avoided global middleware throttling

The limiter is intentionally scoped only to authentication-sensitive routes.

---

## Files Changed

- `backend/config/authRateLimit.js`
- `backend/routes/auth.js`
- `backend/package.json`
- `package.json`
- `spec/auth.rate-limit.spec.cjs`

---

## Security Improvements

This reduces exposure to:

- credential stuffing attacks
- automated brute-force attempts
- password spraying
- event-loop degradation from repeated bcrypt operations
- automated authentication abuse

Excessive requests now return:

```http
429 Too Many Requests
```

with standard rate-limit headers enabled.

---

## Tests

Focused regression coverage added for:

- login limiter blocks excessive requests
- signup limiter blocks excessive requests
- HTTP 429 responses returned correctly
- standard rate-limit headers present
- legitimate requests still succeed under threshold

### Verification

```bash
npx.cmd jasmine spec/auth.rate-limit.spec.cjs
```

Result:

```txt
5 specs, 0 failures
```

Full backend suite was also attempted:

```bash
npm.cmd run test:backend
```

Existing unrelated MongoDB-dependent auth/model specs timed out locally, while all newly-added auth rate-limit tests passed successfully.

---

## Notes

This PR intentionally keeps scope limited to authentication abuse protection.

No CAPTCHA, Redis, account-lockout system, auth architecture rewrite, or unrelated middleware refactors were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to login and signup endpoints to prevent brute-force attacks. Users will receive an HTTP 429 response if they exceed 10 requests per 15-minute window.

* **Tests**
  * Added comprehensive test suite for authentication rate limiting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->