### PR TITLE
Add skeleton loaders and empty state handling to tracker dashboard

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -72,7 +72,7 @@ const Home: React.FC = () => {
 
   const [tab, setTab] = useState(0);
   const [page, setPage] = useState(0);
-
+  const [hasFetched, setHasFetched] = useState(false);
   const [issueFilter, setIssueFilter] = useState("all");
   const [prFilter, setPrFilter] = useState("all");
   const [searchTitle, setSearchTitle] = useState("");
@@ -91,6 +91,7 @@ const Home: React.FC = () => {
     e.preventDefault();
     setPage(0);
     fetchData(username, 1, ROWS_PER_PAGE);
+    setHasFetched(true);
   };
 
   const handlePageChange = (_: unknown, newPage: number) => {
@@ -373,11 +374,11 @@ const Home: React.FC = () => {
                 {currentFilteredData.length === 0 && (
                   <TableRow>
                     <TableCell colSpan={4} align="center">
-                      No Github activity found with current filters.
+                      No GitHub activity found with current filters.
                     </TableCell>
                   </TableRow>
                 )}
-                {currentFilteredData.map((item) => (
+                {hasFetched && currentFilteredData.map((item) => (
                   <TableRow key={item.id}>
 
                     <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -333,13 +333,24 @@ const Home: React.FC = () => {
 
       {loading ? (
         <Box sx={{padding:2}}>
-          {[1,2,3,4,5].map((item)=>(
-            <Skeleton
-            key={item}
-            variant="rounded"
-            height={45}
-            sx={{marginBottom:1.5}}
-            />
+          {[1,2,3,4,5].map((row)=>(
+            <Box 
+            key={row}
+            sx={{
+              display:"flex",
+              marginBottom:2,
+              gap:2,
+            }}
+            >
+            <Skeleton variant="text" width={250}
+       height={35}/>
+            <Skeleton variant="rectangular" width={120}
+       height={35}/>
+            <Skeleton variant="rectangular" width={100}
+       height={35}/>
+            <Skeleton variant="rectangular" width={120}
+       height={35}/>
+            </Box>
           ))}
         </Box>
       ) : (
@@ -359,6 +370,13 @@ const Home: React.FC = () => {
               </TableHead>
 
               <TableBody>
+                {currentFilteredData.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center">
+                      No Github activity found with current filters.
+                    </TableCell>
+                  </TableRow>
+                )}
                 {currentFilteredData.map((item) => (
                   <TableRow key={item.id}>
 

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -24,6 +24,7 @@ import {
   Alert,
   Tabs,
   Tab,
+  Skeleton,
   Select,
   MenuItem,
   FormControl,
@@ -331,8 +332,15 @@ const Home: React.FC = () => {
       )}
 
       {loading ? (
-        <Box display="flex" justifyContent="center" my={4}>
-          <CircularProgress />
+        <Box sx={{padding:2}}>
+          {[1,2,3,4,5].map((item)=>(
+            <Skeleton
+            key={item}
+            variant="rounded"
+            height={45}
+            sx={{marginBottom:1.5}}
+            />
+          ))}
         </Box>
       ) : (
         <Box sx={{ maxHeight: "400px", overflowY: "auto" }}>


### PR DESCRIPTION
### Related Issue
- Closes: #534

---

### Description
Implemented improved loading and empty-state UI for the tracker dashboard.
---

### How Has This Been Tested?
-Tested locally on localhost
-Verified Skeleton loader appears during data fetch
-Verified empty-state message appears correctly
-Verified tracker page still works normally
---

### Screenshots 
<img width="1916" height="1080" alt="Screenshot 2026-05-27 100741" src="https://github.com/user-attachments/assets/6172029d-6514-45b5-9291-a6a34063710f" />

---

### Type of Change
- [x] Bug fix



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced loading experience with skeleton placeholder rows providing better visual feedback during data fetch, replacing the previous spinner interface.
  * Added empty state notification displaying a message when no GitHub activity matches the currently applied filter criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->