### PR TITLE
feat: implement floating scroll-to-top and scroll-to-bottom navigatio…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useLocation } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import ScrollProgressBar from "./components/ScrollProgressBar";
+import ScrollNavigator from "./components/ScrollNavigator";
 import { Toaster } from "react-hot-toast";
 import Router from "./Routes/Router";
 
@@ -16,6 +17,7 @@ function App() {
         {!isFullscreen && <ScrollProgressBar />}
 
         {!isFullscreen && <Navbar />}
+        <ScrollNavigator />
 
         <main className={`flex justify-center items-center ${isFullscreen ? "flex-1" : "flex-grow bg-gray-50 dark:bg-gray-800"}`}>
           <Router />

--- a/src/components/ScrollNavigator.tsx
+++ b/src/components/ScrollNavigator.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+const BOTTOM_THRESHOLD = 24;
+
+const ScrollNavigator = () => {
+  const [showUpButton, setShowUpButton] = useState(false);
+  const [showDownButton, setShowDownButton] = useState(false);
+
+  const updateVisibility = () => {
+    const { documentElement } = document;
+    const scrollTop = window.scrollY;
+    const scrollableHeight =
+      documentElement.scrollHeight - documentElement.clientHeight;
+    const nearBottom = scrollTop >= scrollableHeight - BOTTOM_THRESHOLD;
+
+    setShowUpButton(scrollTop > 300);
+    setShowDownButton(scrollableHeight > 0 && !nearBottom);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const scrollToBottom = () => {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: "smooth",
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", updateVisibility);
+    window.addEventListener("resize", updateVisibility);
+    updateVisibility();
+
+    return () => {
+      window.removeEventListener("scroll", updateVisibility);
+      window.removeEventListener("resize", updateVisibility);
+    };
+  }, []);
+
+  if (!showUpButton && !showDownButton) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-5 right-5 z-50 flex flex-col items-center gap-3">
+      {showUpButton && (
+        <button
+          type="button"
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg shadow-blue-600/30 transition-all duration-200 hover:-translate-y-1 hover:bg-blue-700 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+        >
+          <ChevronUp className="h-6 w-6" />
+        </button>
+      )}
+
+      {showDownButton && (
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-900 text-white shadow-lg shadow-slate-900/30 transition-all duration-200 hover:translate-y-1 hover:bg-slate-700 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white dark:focus:ring-offset-slate-900"
+        >
+          <ChevronDown className="h-6 w-6" />
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ScrollNavigator;


### PR DESCRIPTION

### Related Issue
- Closes: #565 

---

### Description
Added a reusable floating scroll navigator with smooth Up/Down buttons that appears globally across long pages. The Up button shows after the user scrolls down, and the Down button stays hidden near the bottom, making page navigation faster and more convenient.

---

### How Has This Been Tested?
Ran npx eslint src/components/ScrollNavigator.tsx src/App.tsx to verify the new component and global layout injection are clean.
Verified the scroll navigator is mounted from the app shell and uses scroll listeners with cleanup.
Confirmed the existing navbar test suite still passes after the layout change.

---

### Screenshots (if applicable)

<img width="1897" height="967" alt="image" src="https://github.com/user-attachments/assets/a80cb930-841e-4487-9eef-8a2a924b0b4a" />

<img width="1892" height="972" alt="image" src="https://github.com/user-attachments/assets/f01683ea-acdb-4429-9807-216394d12818" />

<img width="1899" height="961" alt="image" src="https://github.com/user-attachments/assets/b7a73585-04a5-4015-8c79-f26630215686" />


---

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update
