### PR TITLE
Fix incorrect repository clone URL in README setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Welcome to **GitHub Tracker**, a web app designed to help you monitor and analyz
 ## 🚀 Setup Guide
 1. Clone the repository to your local machine:
 ```bash
-$ git clone https://github.com/yourusername/github-tracker.git
+$ git clone https://github.com/GitMetricsLab/github_tracker.git
 ```
 
 2. Navigate to the project directory:


### PR DESCRIPTION
## Description

Updated the placeholder clone URL in the README setup guide with the correct repository URL.

## Changes Made

* Replaced incorrect placeholder clone command
* Added correct repository clone URL

## Issue

Closes #569


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository setup instructions in the README with the correct clone URL for improved accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->