### PR TITLE
fix(search): (#169) migrate deprecated GitHub search queries to advanced_search

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -21,6 +21,11 @@ interface FetchFilters {
   state?: string;
 }
 
+type PaginatedSearchResult = {
+  items: GitHubItem[];
+  total: number;
+};
+
 export const useGitHubData = (
   getOctokit: () => Octokit | null
 ) => {
@@ -43,36 +48,42 @@ export const useGitHubData = (
     perPage = 10,
     filters: FetchFilters = {}
   ) => {
-    let q = `author:${username} is:${type}`;
+    const queryParts: string[] = [
+      `author:${username}`,
+      `is:${type}`,
+    ];
 
     if (filters.search) {
-      q += ` ${filters.search} in:title`;
+      queryParts.push(`${filters.search} in:title`);
     }
 
     if (filters.repo) {
-      q += ` repo:${filters.repo}`;
+      queryParts.push(`repo:${filters.repo}`);
     }
 
     if (filters.startDate) {
-      q += ` created:>=${filters.startDate}`;
+      queryParts.push(`created:>=${filters.startDate}`);
     }
 
     if (filters.endDate) {
-      q += ` created:<=${filters.endDate}`;
+      queryParts.push(`created:<=${filters.endDate}`);
     }
 
     if (filters.state === 'open' || filters.state === 'closed') {
-      q += ` is:${filters.state}`;
+      queryParts.push(`is:${filters.state}`);
     }
 
     if (filters.state === 'merged' && type === 'pr') {
-      q += ` is:merged`;
+      queryParts.push('is:merged');
     }
+
+    const q = queryParts.join(' AND ');
 
     const response = await octokit.request(
       'GET /search/issues',
       {
         q,
+        advanced_search: true,
         sort: 'created',
         order: 'desc',
         per_page: perPage,
@@ -112,7 +123,7 @@ export const useGitHubData = (
         const shouldFetchPrs =
           activeTab === 'pr' || activeTab === 'both';
 
-        const requests: Promise<any>[] = [];
+        const requests: Promise<PaginatedSearchResult>[] = [];
 
         if (shouldFetchIssues) {
           requests.push(

--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -54,7 +54,9 @@ export const useGitHubData = (
     ];
 
     if (filters.search) {
-      queryParts.push(`${filters.search} in:title`);
+      const escapedSearch =
+        filters.search.trim().replace(/"/g, '\\"');
+      queryParts.push(`in:title:"${escapedSearch}"`);
     }
 
     if (filters.repo) {

--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -29,8 +29,13 @@ export default function ContributorProfile() {
         const userData = await userRes.json();
         setProfile(userData);
 
+        const searchParams = new URLSearchParams({
+          q: `author:${username} AND is:pr`,
+          advanced_search: "true",
+        });
+
         const prsRes = await fetch(
-          `https://api.github.com/search/issues?q=author:${username}+type:pr`
+          `https://api.github.com/search/issues?${searchParams.toString()}`
         );
         const prsData = await prsRes.json();
         setPRs(prsData.items);

--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -37,8 +37,14 @@ export default function ContributorProfile() {
         const prsRes = await fetch(
           `https://api.github.com/search/issues?${searchParams.toString()}`
         );
+
+        if (!prsRes.ok) {
+          setPRs([]);
+          return;
+        }
+
         const prsData = await prsRes.json();
-        setPRs(prsData.items);
+        setPRs(prsData.items || []);
       } catch {
         toast.error("Failed to fetch user data.");
       } finally {


### PR DESCRIPTION
### Related Issue

* Closes: #169

---

### Description

This PR updates deprecated GitHub Search API query usage by migrating affected frontend search requests to the newer `advanced_search` query format.

### Changes made

* Updated GitHub search query construction to use explicit `AND`-based query composition
* Added `advanced_search: true` to affected `/search/issues` requests
* Replaced manual query string construction with `URLSearchParams`
* Added minimal typing improvement in `useGitHubData.ts`

### Files changed

* `src/hooks/useGitHubData.ts`
* `src/pages/ContributorProfile/ContributorProfile.tsx`

### Scope

The implementation was intentionally kept minimal and localized to the deprecated search query paths to avoid unrelated behavioral or architectural changes.

---

### How Has This Been Tested?

* ✅ `npm run build` passed successfully
* ⚠️ `npm run lint` still reports existing unrelated repository issues outside the scope of this PR

---

### Screenshots (if applicable)

N/A

---

### Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced GitHub API query handling for improved reliability and type safety in data fetching operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GitMetricsLab/github_tracker/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->