### PR TITLE
fix: handle GitHub API error response in ContributorProfile

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -27,6 +27,7 @@ export default function ContributorProfile() {
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
         const userData = await userRes.json();
+        if (userData.message) throw new Error(userData.message);
         setProfile(userData);
 
         const prsRes = await fetch(

--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -27,7 +27,7 @@ export default function ContributorProfile() {
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
         const userData = await userRes.json();
-        if (userData.message) throw new Error(userData.message);
+        if (!userRes.ok) throw new Error(userData.message || `HTTP error: ${userRes.status}`);
         setProfile(userData);
 
         const prsRes = await fetch(


### PR DESCRIPTION
### Related Issue
- Closes: #<your issue number>

---

### Description
When the GitHub API returns an error (e.g. user not found, rate limit exceeded), 
the response is `{ message: 'Not Found' }` instead of a valid user object. 
The component was accessing `profile.avatar_url` on this error object, causing 
a runtime crash. Added a guard to throw a proper error before any profile 
properties are accessed.

---

### How Has This Been Tested?
Manually tested by entering a non-existent GitHub username. Without the fix 
the app crashes. With the fix an error is thrown and handled gracefully.

---

### Screenshots (if applicable)
N/A

---

### Type of Change
- [x] Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling when fetching GitHub user data to ensure error messages are properly displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->