### PR TITLE
fix: remove authError from useGitHubAuth destructure — always undefined

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -55,7 +55,6 @@ const Home: React.FC = () => {
     setUsername,
     token,
     setToken,
-    error: authError,
     getOctokit,
   } = useGitHubAuth();
 
@@ -324,9 +323,9 @@ const Home: React.FC = () => {
         </FormControl>
       </Box>
 
-      {(authError || dataError) && (
+      {dataError && (
         <Alert severity="error" sx={{ mb: 3 }}>
-          {authError || dataError}
+          {dataError}
         </Alert>
       )}
 


### PR DESCRIPTION
### Related Issue
- Closes: #625 

---

### Description
`useGitHubAuth` never exposed an `error` field, so destructuring
`error: authError` from it always resulted in `authError` being
`undefined`. This caused auth errors to be silently swallowed and
never displayed to the user.

- Removed `error: authError` from the destructure
- Cleaned up the Alert block to rely only on `dataError`
---

### How Has This Been Tested?
- Verified `useGitHubAuth` return value — confirms no `error` field exists
- Entered an invalid token and confirmed `dataError` message displays correctly
- Entered a valid token and confirmed no error alert appears

---

### Screenshots (if applicable)
N/A

---

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling in Tracker component. Error messages now display only for data-related issues, with the alert content derived directly from data errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->