### PR TITLE
missing HTTP response validation in the profile fetch logic

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -26,6 +26,9 @@ export default function ContributorProfile() {
 
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
+        if (!userRes.ok) {
+          throw new Error("Failed to fetch user data.");
+        }
         const userData = await userRes.json();
         setProfile(userData);
 


### PR DESCRIPTION
### Related Issue
- Closes: #636


---

### Description
This PR fixes a critical bug where the application would silently fail or crash if the GitHub API returned a non-200 response (like a 404 for a missing user). Added an `if (userRes.ok)` check to validate the HTTP response status before attempting to parse the JSON. 

---

### How Has This Been Tested?
- Ran the local development server.
- Searched for a valid GitHub username to ensure the profile still loads correctly.
- Searched for an invalid/non-existent GitHub username to verify the app gracefully handles the error instead of crashing.



---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GitHub user profile data retrieval to ensure users receive proper error notifications when the request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->