### PR TITLE
Activity Feed Errors

### DIFF
--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -33,9 +33,14 @@ export default function ActivityFeed({ username }: { username: string }) {
         const res = await fetch(
           `https://api.github.com/users/${username}/events`
         );
-        const data = await res.json();
 
-        setEvents(data);
+        if (!res.ok) {
+          console.error(`Error fetching GitHub events: ${res.status}`);
+          setEvents([]);
+        } else {
+          const data = await res.json();
+          setEvents(data);
+        }
         setLoading(false);
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
### Related Issue
- Closes: #637


---

### Description
Added response validation to the `ActivityFeed` component. Previously, if the GitHub API returned an error, the code would attempt to parse the error object as an array, causing runtime crashes. The fetch logic now checks `res.ok` and safely defaults to an empty array `[]` if the fetch fails.

---

### How Has This Been Tested?
- Started the application locally.
- Verified that the activity feed populates correctly for active users.
- Simulated an API failure/rate limit to ensure the feed safely renders an empty state without breaking the UI.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update