### PR TITLE
React Key Anti-Pattern in PR List

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -77,10 +77,10 @@ export default function ContributorProfile() {
       <h3 className="text-xl font-semibold mt-6 mb-2">Pull Requests</h3>
       {prs.length > 0 ? (
         <ul className="list-disc ml-6 space-y-2">
-          {prs.map((pr, i) => {
+          {prs.map((pr) => {
             const repoName = pr.repository_url.split("/").slice(-2).join("/");
             return (
-              <li key={i}>
+              <li key={pr.html_url}>
                 <a
                   href={pr.html_url}
                   target="_blank"


### PR DESCRIPTION
### Related Issue
- Closes: #638


---

### Description
Refactored the pull request list rendering in `ContributorProfile.tsx` to use unique identifiers (`pr.html_url`) as React keys instead of array indices. This eliminates a common React anti-pattern that can cause state misalignment and rendering bugs when list items re-render.

---

### How Has This Been Tested?
- Tested locally in the browser.
- Verified that the PR list renders accurately.
- Checked the browser console to confirm the React "missing/duplicate key" warnings have been resolved.


---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Code style update
- [ ] Breaking change
- [ ] Documentation update