### PR TITLE
missing HTTP response validation in the profile fetch logic

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -26,6 +26,7 @@ export default function ContributorProfile() {
 
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
+        if (!userRes.ok) throw new Error("Failed to fetch user profile");
         const userData = await userRes.json();
         setProfile(userData);
 


### PR DESCRIPTION
### Related Issue
- Closes: #639 

---

### Description
This PR resolves a critical bug where the application would silently fail or crash if the GitHub API returned a non-200 response (such as a 404 for a missing user). Added an `if (!userRes.ok)` check to validate the HTTP response status before attempting to parse the JSON. 

---

### How Has This Been Tested?
- Ran the local development server.
- Searched for a valid GitHub username to ensure the profile loads correctly.
- Searched for an invalid GitHub username to verify the app throws the error gracefully instead of crashing the UI.



### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update
