### PR TITLE
Unhandled API Response in ActivityFeed

### DIFF
--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -33,9 +33,16 @@ export default function ActivityFeed({ username }: { username: string }) {
         const res = await fetch(
           `https://api.github.com/users/${username}/events`
         );
+
+        if (!res.ok) {
+          setEvents([]);
+          setLoading(false);
+          return;
+        }
+
         const data = await res.json();
 
-        setEvents(data);
+        setEvents(Array.isArray(data) ? data : []);
         setLoading(false);
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
### Related Issue
- Closes: #641

---

### Description
Added response validation to the `ActivityFeed` component. Previously, if the GitHub API hit a rate limit or returned an error, the code would attempt to parse the error object as an array, resulting in runtime crashes. The fetch logic now strictly checks `res.ok` before parsing to ensure stability.

---

### How Has This Been Tested?
- Started the application locally.
- Verified that the activity feed populates correctly for active users.
- Simulated an API rate limit/failure to ensure the feed safely handles the error state without breaking the surrounding UI.


---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update