### PR TITLE
feat: add recent search history for tracked GitHub profiles

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -93,11 +93,11 @@ export const useGitHubData = (
       perPage = 10,
       activeTab: 'issue' | 'pr' | 'both' = 'both',
       filters: FetchFilters = {}
-    ) => {
+    ): Promise<boolean> => {
       const octokit = getOctokit();
 
       if (!octokit || !username.trim() || rateLimited) {
-        return;
+        return false;
       }
 
       const requestId = ++lastRequestId.current;
@@ -144,7 +144,7 @@ export const useGitHubData = (
 
         // Ignore stale requests
         if (requestId !== lastRequestId.current) {
-          return;
+          return false;
         }
 
         let resultIndex = 0;
@@ -186,9 +186,10 @@ export const useGitHubData = (
         }
 
         setRateLimited(false);
+        return !hasRejected;
       } catch (err: unknown) {
         if (requestId !== lastRequestId.current) {
-          return;
+          return false;
         }
 
         const error = err as {
@@ -230,6 +231,7 @@ export const useGitHubData = (
             'Unable to fetch GitHub data. Please verify the username, token, or network connection.'
           );
         }
+        return false;
       } finally {
         if (requestId === lastRequestId.current) {
           setLoading(false);

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -28,6 +28,7 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
+  Typography,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useGitHubAuth } from "../../hooks/useGitHubAuth";
@@ -35,6 +36,8 @@ import { useGitHubData } from "../../hooks/useGitHubData";
 import { KeyIcon } from "lucide-react";
 
 const ROWS_PER_PAGE = 10;
+const RECENT_SEARCHES_KEY = 'githubTrackerRecentSearches';
+const MAX_RECENT_SEARCHES = 10;
 
 interface GitHubItem {
   id: number;
@@ -71,6 +74,7 @@ const Home: React.FC = () => {
 
   const [tab, setTab] = useState(0);
   const [page, setPage] = useState(0);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
 
   const [issueFilter, setIssueFilter] = useState("all");
   const [prFilter, setPrFilter] = useState("all");
@@ -79,21 +83,117 @@ const Home: React.FC = () => {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
-  // Fetch data when username, tab, or page changes
+  const normalizeSearchUsername = (value: string): string => value.trim();
+
+  const loadRecentSearches = (): string[] => {
+    if (typeof window === 'undefined') {
+      return [];
+    }
+
+    try {
+      const stored = localStorage.getItem(RECENT_SEARCHES_KEY);
+      if (!stored) {
+        return [];
+      }
+
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .filter((item): item is string => typeof item === 'string')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .slice(0, MAX_RECENT_SEARCHES);
+    } catch {
+      return [];
+    }
+  };
+
+  const persistRecentSearches = (searches: string[]) => {
+    setRecentSearches(searches);
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches));
+  };
+
+  const addRecentSearch = (value: string) => {
+    const normalized = normalizeSearchUsername(value);
+    if (!normalized) {
+      return;
+    }
+
+    const updated = [
+      normalized,
+      ...recentSearches.filter(
+        (item) => item.toLowerCase() !== normalized.toLowerCase()
+      ),
+    ].slice(0, MAX_RECENT_SEARCHES);
+
+    persistRecentSearches(updated);
+  };
+
+  const clearRecentSearches = () => {
+    setRecentSearches([]);
+    localStorage.removeItem(RECENT_SEARCHES_KEY);
+  };
+
+  useEffect(() => {
+    setRecentSearches(loadRecentSearches());
+  }, []);
+
+  // Fetch data when tab or page changes.
+  // Do not fetch on intermediate username typing.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (username) {
       fetchData(username, page + 1, ROWS_PER_PAGE);
     }
   }, [tab, page]);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault();
+
+    const normalizedUsername = normalizeSearchUsername(username);
+    if (!normalizedUsername) {
+      return;
+    }
+
+    setUsername(normalizedUsername);
     setPage(0);
-    fetchData(username, 1, ROWS_PER_PAGE);
+
+    const wasSuccessful = await fetchData(
+      normalizedUsername,
+      1,
+      ROWS_PER_PAGE
+    );
+
+    if (wasSuccessful) {
+      addRecentSearch(normalizedUsername);
+    }
   };
 
   const handlePageChange = (_: unknown, newPage: number) => {
     setPage(newPage);
+  };
+
+  const handleRecentSearchClick = async (value: string) => {
+    const normalizedUsername = normalizeSearchUsername(value);
+    if (!normalizedUsername) {
+      return;
+    }
+
+    setUsername(normalizedUsername);
+    setPage(0);
+
+    const wasSuccessful = await fetchData(
+      normalizedUsername,
+      1,
+      ROWS_PER_PAGE
+    );
+
+    if (wasSuccessful) {
+      addRecentSearch(normalizedUsername);
+    }
   };
 
   const formatDate = (dateString: string): string =>
@@ -240,6 +340,52 @@ const Home: React.FC = () => {
             </Button>
           </Box>
         </form>
+
+        {recentSearches.length > 0 && (
+          <Box
+            sx={{
+              mt: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 2,
+                flexWrap: 'wrap',
+              }}
+            >
+              <Typography variant="subtitle1" sx={{ color: theme.palette.text.primary }}>
+                Recent searches
+              </Typography>
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={clearRecentSearches}
+              >
+                Clear History
+              </Button>
+            </Box>
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              {recentSearches.map((item) => (
+                <Button
+                  key={item}
+                  variant="outlined"
+                  size="small"
+                  onClick={() => handleRecentSearchClick(item)}
+                  sx={{ textTransform: 'none' }}
+                >
+                  {item}
+                </Button>
+              ))}
+            </Box>
+          </Box>
+        )}
       </Paper>
 
       {/* Filters */}


### PR DESCRIPTION
### Related Issue

* Closes: #659

---

### Description

This PR adds a **Recent Search History** feature to the Tracker page, allowing users to quickly revisit previously searched GitHub profiles.

#### Changes Made

* Added persistent recent search history using `localStorage`
* Stores up to 10 recently searched GitHub usernames
* Prevents duplicate entries by moving existing usernames to the top
* Automatically loads saved history on page refresh
* Added clickable recent search items for one-click profile tracking
* Added a **Clear History** button to remove all stored searches
* Trimmed usernames and ignored empty inputs before processing
* Updated the search flow to save usernames only after a successful data fetch

#### Benefits

* Improves user experience by reducing repetitive typing
* Makes it easier to revisit frequently tracked GitHub profiles
* Requires no backend changes
* Integrates seamlessly with the existing Tracker workflow

---

### How Has This Been Tested?

* Verified recent searches are stored in `localStorage`
* Verified history persists across page refreshes
* Verified duplicate usernames are moved to the top instead of being duplicated
* Verified empty and whitespace-only usernames are ignored
* Verified clicking a recent search automatically triggers the existing search flow
* Verified the **Clear History** button removes all stored entries immediately
* Verified usernames are saved only after successful GitHub data retrieval

---

### Screenshots (if applicable)

N/A – This feature primarily adds functionality and persistence behavior. UI changes are minimal and integrated into the existing Tracker page.

---

### Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Recent Searches" panel displaying your previously searched usernames for convenient quick re-access to recent lookups
  * Added "Clear History" button to remove and manage stored search history
  * Search history automatically persists across browser sessions for continued access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->