### PR TITLE
fix(contributor): show repository-specific pull requests

### DIFF
--- a/src/pages/ContributorProfile/ContributorProfile.tsx
+++ b/src/pages/ContributorProfile/ContributorProfile.tsx
@@ -1,6 +1,8 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
+// --- FIX: Import the repo constant ---
+import { GITHUB_REPO } from "@/utils/constants";
 
 type PR = {
   title: string;
@@ -14,27 +16,54 @@ type Profile = {
   bio: string;
 };
 
+type ErrorType = "not_found" | "api_error" | null;
+
 export default function ContributorProfile() {
   const { username } = useParams();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [prs, setPRs] = useState<PR[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorType>(null);
 
   useEffect(() => {
     async function fetchData() {
       if (!username) return;
 
+      setError(null);
+
       try {
         const userRes = await fetch(`https://api.github.com/users/${username}`);
-        const userData = await userRes.json();
-        setProfile(userData);
 
+        if (!userRes.ok) {
+          if (userRes.status === 404) {
+            setError("not_found");
+          } else {
+            setError("api_error");
+          }
+          setProfile(null);
+          setPRs([]);
+          return;
+        }
+
+        const userData = await userRes.json();
+        setProfile(userData as Profile);
+
+        // --- FIX: Scoped to this repo only using GITHUB_REPO constant ---
         const prsRes = await fetch(
-          `https://api.github.com/search/issues?q=author:${username}+type:pr`
+          `https://api.github.com/search/issues?q=repo:${GITHUB_REPO}+author:${username}+type:pr`
         );
-        const prsData = await prsRes.json();
-        setPRs(prsData.items);
+
+        if (!prsRes.ok) {
+          setPRs([]);
+          toast.error("Failed to load pull requests.");
+        } else {
+          const prsData = await prsRes.json();
+          setPRs(prsData.items ?? []);
+        }
       } catch {
+        setError("api_error");
+        setProfile(null);
+        setPRs([]);
         toast.error("Failed to fetch user data.");
       } finally {
         setLoading(false);
@@ -51,10 +80,23 @@ export default function ContributorProfile() {
 
   if (loading) return <div className="text-center mt-10">Loading...</div>;
 
-  if (!profile)
+  if (error === "not_found") {
     return (
-      <div className="text-center mt-10 text-red-600">User not found.</div>
+      <div className="text-center mt-10 text-red-600">
+        User not found.
+      </div>
     );
+  }
+
+  if (error === "api_error") {
+    return (
+      <div className="text-center mt-10 text-yellow-600">
+        Unable to load contributor profile. Please try again later.
+      </div>
+    );
+  }
+
+  if (!profile) return null;
 
   return (
     <div className="max-w-3xl mx-auto mt-2 mb-2 p-4 bg-white dark:bg-gray-800 dark:text-white shadow-xl rounded-xl">

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,3 +2,6 @@ export const GITHUB_REPO_API_BASE = "https://api.github.com/repos/GitMetricsLab/
 
 // endpoints:
 export const GITHUB_REPO_CONTRIBUTORS_URL = `${GITHUB_REPO_API_BASE}/contributors`;
+
+// --- FIX: Repo identifier for scoped PR search queries ---
+export const GITHUB_REPO = "GitMetricsLab/github_tracker";


### PR DESCRIPTION
### Related Issue
- Closes: #628

---

### Description

Updated the contributor profile page to fetch pull requests only from the current project repository instead of all GitHub repositories.

Previously, the GitHub search query used:

author:${username}+type:pr

which returned pull requests created by the contributor across all repositories on GitHub.

This change updates the query to include the project repository filter so that only pull requests related to this project are displayed on the contributor profile page.

Changes made:
- Updated the GitHub search query to include the repository name
- Ensured contributor profiles display only project-related pull requests
- Improved accuracy and relevance of contributor information

---

### How Has This Been Tested?

- Opened contributor profiles from the Contributors page
- Verified that only pull requests from the project repository are displayed
- Confirmed that unrelated pull requests from other repositories no longer appear
- Verified that the profile page loads correctly without errors

---

### Screenshots (if applicable)

N/A

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update