### PR TITLE
Add DeveloperSummary component to display GitHub profile insights

### DIFF
--- a/src/components/DeveloperSummary.tsx
+++ b/src/components/DeveloperSummary.tsx
@@ -18,20 +18,66 @@ interface DeveloperProfile {
 
 interface Props {
   username: string;
+  token?: string;
 }
 
-const DeveloperSummary: React.FC<Props> = ({ username }) => {
+const DeveloperSummary: React.FC<Props> = ({ username, token }) => {
   const [profile, setProfile] =
     useState<DeveloperProfile | null>(null);
 
-  useEffect(() => {
-    if (!username) return;
+useEffect(() => {
+  if (!username.trim()) {
+    setProfile(null);
+    return;
+  }
 
-    fetch(`https://api.github.com/users/${username}`)
-      .then((res) => res.json())
-      .then((data) => setProfile(data))
-      .catch(console.error);
-  }, [username]);
+  const controller = new AbortController();
+
+  const timeout = setTimeout(async () => {
+    try {
+      setProfile(null);
+
+      const response = await fetch(
+        `https://api.github.com/users/${username}`,
+        {
+          signal: controller.signal,
+          ...(token && {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData =
+          await response.json().catch(() => null);
+
+        throw new Error(
+          errorData?.message ||
+            `GitHub request failed (${response.status})`
+        );
+      }
+
+      const data = await response.json();
+
+      setProfile(data);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.name !== "AbortError"
+      ) {
+        console.error(error);
+        setProfile(null);
+      }
+    }
+  }, 500);
+
+  return () => {
+    clearTimeout(timeout);
+    controller.abort();
+  };
+}, [username, token]);
 
   if (!profile) return null;
 

--- a/src/components/DeveloperSummary.tsx
+++ b/src/components/DeveloperSummary.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from "react";
+import {
+  Paper,
+  Typography,
+  Box,
+  Avatar,
+  Chip,
+} from "@mui/material";
+
+interface DeveloperProfile {
+  name: string;
+  bio: string;
+  followers: number;
+  following: number;
+  public_repos: number;
+  avatar_url: string;
+}
+
+interface Props {
+  username: string;
+}
+
+const DeveloperSummary: React.FC<Props> = ({ username }) => {
+  const [profile, setProfile] =
+    useState<DeveloperProfile | null>(null);
+
+  useEffect(() => {
+    if (!username) return;
+
+    fetch(`https://api.github.com/users/${username}`)
+      .then((res) => res.json())
+      .then((data) => setProfile(data))
+      .catch(console.error);
+  }, [username]);
+
+  if (!profile) return null;
+
+  return (
+    <Paper
+      elevation={2}
+      sx={{
+        p: 3,
+        mb: 3,
+        borderRadius: 3,
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 2,
+          mb: 2,
+        }}
+      >
+        <Avatar
+          src={profile.avatar_url}
+          sx={{ width: 64, height: 64 }}
+        />
+
+        <Box>
+          <Typography variant="h6">
+            {profile.name || username}
+          </Typography>
+
+          {profile.bio && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+            >
+              {profile.bio}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          flexWrap: "wrap",
+          mb: 2,
+        }}
+      >
+        <Chip
+          label={`${profile.public_repos} Repositories`}
+        />
+        <Chip
+          label={`${profile.followers} Followers`}
+        />
+        <Chip
+          label={`${profile.following} Following`}
+        />
+      </Box>
+
+      <Typography>
+        {profile.name || username} has{" "}
+        {profile.public_repos} public repositories and{" "}
+        {profile.followers} followers, showing active
+        participation in the GitHub community.
+      </Typography>
+    </Paper>
+  );
+};
+
+export default DeveloperSummary;

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -243,7 +243,10 @@ const Home: React.FC = () => {
           </Box>
         </form>
       </Paper>
-      <DeveloperSummary username={username} />
+      <DeveloperSummary
+        username={username}
+        token={token}
+      />
       {/* Filters */}
       <Box sx={{ mb: 2, display: "flex", flexWrap: "wrap", gap: 2 }}>
         <TextField

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -33,6 +33,8 @@ import { useTheme } from "@mui/material/styles";
 import { useGitHubAuth } from "../../hooks/useGitHubAuth";
 import { useGitHubData } from "../../hooks/useGitHubData";
 import { KeyIcon } from "lucide-react";
+import DeveloperSummary from "../../components/DeveloperSummary";
+
 
 const ROWS_PER_PAGE = 10;
 
@@ -241,7 +243,7 @@ const Home: React.FC = () => {
           </Box>
         </form>
       </Paper>
-
+      <DeveloperSummary username={username} />
       {/* Filters */}
       <Box sx={{ mb: 2, display: "flex", flexWrap: "wrap", gap: 2 }}>
         <TextField


### PR DESCRIPTION
### Related Issue

* Closes: #664

---

### Description

Added a **Developer Summary** section to the Tracker page that displays GitHub profile insights based on the entered username.

#### Changes Made

* Created a new `DeveloperSummary` component.
* Fetched GitHub user profile information using the GitHub API.
* Displayed key profile details including:

  * Profile avatar
  * Name
  * Bio
  * Public repositories count
  * Followers and following count
* Integrated the Developer Summary card into the Tracker page.
* Added responsive styling using Material UI components.

---

### How Has This Been Tested?

* Ran the application locally using `npm run dev`.
* Tested with multiple GitHub usernames.
* Verified that profile information loads correctly and updates based on the entered username.
* Confirmed that existing tracker functionality remains unaffected.

---

### Screenshots 
<img width="1747" height="838" alt="image" src="https://github.com/user-attachments/assets/5b491bcf-0f72-4972-9475-9c31faa8a413" />

### Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a developer profile summary card on the tracker page showing GitHub avatar, display name (falls back to username), bio, public repo count, followers, and following.
  * Profile fetching is debounced to reduce requests and supports optional authorization tokens.
  * Network and API errors are handled gracefully so the UI remains stable when profiles cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->