### PR TITLE
feat(auth): integrate production-ready session middleware with secure cookie configurations

### DIFF
--- a/backend/config/passportConfig.js
+++ b/backend/config/passportConfig.js
@@ -7,9 +7,9 @@ passport.use(
         { usernameField: "email" },
         async (email, password, done) => {
             try {
-                const user = await User.findOne( {email} ).select("+password");;
+                const user = await User.findOne({ email }).select("+password");
                 if (!user) {
-                    return done(null, false, { message: 'Email is invalid '});
+                    return done(null, false, { message: 'Email is invalid ' });
                 }
 
                 const isMatch = await user.comparePassword(password);
@@ -18,7 +18,7 @@ passport.use(
                 }
 
                 return done(null, {
-                    id : user._id.toString(),
+                    id: user._id.toString(),
                     username: user.username,
                     email: user.email
                 });
@@ -38,10 +38,14 @@ passport.serializeUser((user, done) => {
 passport.deserializeUser(async (id, done) => {
     try {
         const user = await User.findById(id);
+        
+        // 🛡️ Safety check: If the user record no longer exists in MongoDB, exit safely
+        // This prevents the application from throwing an unhandled TypeError downstream
         if (!user) {
-            return done(null, false);
+            return done(null, false); // Gracefully invalidates the cookie and ends the request loop
         }
-        done(null,user);
+        
+        done(null, user);
     } catch (err) {
         done(err, null);
     }

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,10 +28,16 @@ app.use(cors({
 
 // Middleware
 app.use(bodyParser.json());
+
 app.use(session({
     secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
+    cookie: {
+        maxAge: 24 * 60 * 60 * 1000,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax"
+    }
 }));
 app.use(passport.initialize());
 app.use(passport.session());


### PR DESCRIPTION
Add session middleware with cookie settings

### Related Issue
- Closes: #678 

---

### Description
🧱 The Architectural Context:
Cross-origin resource transactions rely on strict browser-level tracking rules. For session-based authentication to maintain continuity across distinct hosting domains (e.g., a frontend hosted on Netlify communicating with a backend hosted on Render), cookies must be explicitly configured with secure, cross-site transport policies.

❌ The Failure Mechanism:
The original session configuration initialized express-session with default fallback cookie settings. While this setup works flawlessly on localhost where the frontend and backend share a common root network origin, it breaks entirely in production. Modern web browsers block cross-origin state tracking by default, causing the client browser to immediately drop and discard incoming session cookies from the server.

💥 The Impact:
Users are completely unable to log in or maintain an active authentication state on the deployed production application. Although the backend processes validation endpoints successfully and returns validation headers, the browser drops the cookie payload on subsequent API requests, throwing infinite authorization errors.

✅ The Solution:
Updated the session middleware configuration inside service.js to include a dynamic, environment-aware cookie parameter object. By programmatically assessing process.env.NODE_ENV, the cookie scales up its policy permissions to secure: true (forcing HTTPS transmission) and sameSite: "none" (authorizing cross-site storage) explicitly when running in production.

---

### How Has This Been Tested?
Local Interoperability Regression Testing: Verified that local development on localhost:5173 retains cookie assignment under standard lax rules without breaking developer flows.

Production Environmental Simulation: Validated through mock environment settings that the cookie payload structures alter correctly to enforce strict cross-origin permissions when the production flag is triggered.

---

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Breaking change
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Session cookie timeout configured to 24 hours with secure flag enabled in production and sameSite policy applied based on environment.

* **Style**
  * Minor code formatting refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->