### PR TITLE
634 commit 1

### DIFF
--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -7,7 +7,6 @@ export const useGitHubAuth = () => {
   const [error, setError] = useState('');
 
   const octokit = useMemo(() => {
-    setError('');
     if (!username) return null;
     if(token){
       return new Octokit({ auth: token });
@@ -15,21 +14,35 @@ export const useGitHubAuth = () => {
     return new Octokit();
   }, [username, token]);
 
+  // Clear error when username or token changes, before validation runs
+  useEffect(() => {
+    setError('');
+  }, [username, token]);
+
   // Validate token format and authentication on mount or change
   useEffect(() => {
     if (!token || !username) {
-      setError('');
       return;
     }
+
+    const controller = new AbortController();
 
     const validateAuth = async () => {
       if (!octokit) return;
       
       try {
         // Attempt a simple API call to verify the token is valid
-        await octokit.request('GET /user');
-        setError('');
+        await octokit.request('GET /user', { request: { signal: controller.signal } });
+        // Only update state if request was not aborted
+        if (!controller.signal.aborted) {
+          setError('');
+        }
       } catch (err: unknown) {
+        // Ignore if request was aborted
+        if (controller.signal.aborted) {
+          return;
+        }
+
         const error = err as {
           status?: number;
           message?: string;
@@ -49,7 +62,10 @@ export const useGitHubAuth = () => {
 
     // Validate on token change (but with a small delay to avoid excessive API calls during typing)
     const timeoutId = setTimeout(validateAuth, 500);
-    return () => clearTimeout(timeoutId);
+    return () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
   }, [token, username, octokit]);
 
   const getOctokit = () => octokit;

--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -1,17 +1,56 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Octokit } from '@octokit/core';
 
 export const useGitHubAuth = () => {
   const [username, setUsername] = useState('');
   const [token, setToken] = useState('');
+  const [error, setError] = useState('');
 
   const octokit = useMemo(() => {
+    setError('');
     if (!username) return null;
     if(token){
-    return new Octokit({ auth: token });
+      return new Octokit({ auth: token });
     }
     return new Octokit();
   }, [username, token]);
+
+  // Validate token format and authentication on mount or change
+  useEffect(() => {
+    if (!token || !username) {
+      setError('');
+      return;
+    }
+
+    const validateAuth = async () => {
+      if (!octokit) return;
+      
+      try {
+        // Attempt a simple API call to verify the token is valid
+        await octokit.request('GET /user');
+        setError('');
+      } catch (err: unknown) {
+        const error = err as {
+          status?: number;
+          message?: string;
+        };
+
+        if (error.status === 401) {
+          setError('Invalid personal access token. Please check and try again.');
+        } else if (error.status === 403) {
+          setError('Token has insufficient permissions or has expired.');
+        } else if (error.message?.includes('Bad credentials')) {
+          setError('Bad credentials. Please verify your personal access token.');
+        } else {
+          setError(`Authentication error: ${error.message || 'Unknown error'}`);
+        }
+      }
+    };
+
+    // Validate on token change (but with a small delay to avoid excessive API calls during typing)
+    const timeoutId = setTimeout(validateAuth, 500);
+    return () => clearTimeout(timeoutId);
+  }, [token, username, octokit]);
 
   const getOctokit = () => octokit;
 
@@ -20,6 +59,8 @@ export const useGitHubAuth = () => {
     setUsername,
     token,
     setToken,
+    error,
+    setError,
     getOctokit,
   };
 };

--- a/src/pages/Contact/Contact.tsx
+++ b/src/pages/Contact/Contact.tsx
@@ -175,7 +175,7 @@ function Contact() {
                             mode === "dark"
                               ? "text-gray-400"
                               : "text-gray-500"
-                          }` }
+                          }`}
                         >
                           {sub}
                         </p>

--- a/src/pages/Contact/Contact.tsx
+++ b/src/pages/Contact/Contact.tsx
@@ -175,7 +175,7 @@ function Contact() {
                             mode === "dark"
                               ? "text-gray-400"
                               : "text-gray-500"
-                          }`}
+                          }` }
                         >
                           {sub}
                         </p>

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -324,9 +324,15 @@ const Home: React.FC = () => {
         </FormControl>
       </Box>
 
-      {(authError || dataError) && (
+      {authError && (
         <Alert severity="error" sx={{ mb: 3 }}>
-          {authError || dataError}
+          <strong>Authentication Error:</strong> {authError}
+        </Alert>
+      )}
+
+      {dataError && !authError && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          <strong>Data Fetch Error:</strong> {dataError}
         </Alert>
       )}
 


### PR DESCRIPTION
### Related Issue

* Closes: #634

---

### Description

This PR fixes authentication error handling on the Tracker page by properly surfacing GitHub authentication failures to users.

#### Changes Made

* Enhanced `useGitHubAuth` to expose an `error` state for authentication-related failures.
* Added automatic GitHub token validation with a debounce when the token changes.
* Implemented validation against GitHub's `GET /user` endpoint to verify token authenticity.
* Added specific handling for common authentication scenarios:

  * Invalid personal access token (401)
  * Insufficient permissions or expired token (403)
  * Bad credentials
* Updated the Tracker page to consume and display `authError`.
* Separated authentication errors from data-fetching errors for clearer user feedback.

#### User Impact

Users now receive clear and actionable authentication error messages instead of generic data-fetching errors, making it easier to identify and resolve GitHub credential issues.

---

### How Has This Been Tested?

* Verified that the application compiles successfully with no syntax errors.
* Tested invalid GitHub personal access token scenarios.
* Tested authentication failure handling and error state propagation.
* Confirmed that authentication errors and data-fetching errors are displayed independently on the Tracker page.
* Verified that valid authentication flows continue to work as expected.

---

### Screenshots (if applicable)

N/A

---

### Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub tokens are now automatically validated and provide clearer, specific authentication error messages.
  * Authentication error state can be programmatically set/cleared, improving UI feedback.

* **Bug Fixes**
  * Authentication failures and data-loading errors are shown as separate alerts for clearer diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->