### PR TITLE
fix(search): strip GitHub qualifier injection from search filter input

### DIFF
--- a/src/hooks/useGitHubData.ts
+++ b/src/hooks/useGitHubData.ts
@@ -46,7 +46,17 @@ export const useGitHubData = (
     let q = `author:${username} is:${type}`;
 
     if (filters.search) {
-      q += ` ${filters.search} in:title`;
+      // Strip GitHub search qualifiers (key:value pairs) from the free-text
+      // search term before appending it to the query string. Allowing raw
+      // qualifier injection lets a caller override repo:, author:, is:, and
+      // other operators already set by the hook, potentially leaking data
+      // from repositories outside the intended scope.
+      const sanitizedSearch = filters.search
+        .replace(/[a-zA-Z_-]+:[^\s]*/g, '')
+        .trim();
+      if (sanitizedSearch) {
+        q += ` ${sanitizedSearch} in:title`;
+      }
     }
 
     if (filters.repo) {


### PR DESCRIPTION
## Description

The search filter value in useGitHubData was appended verbatim to the GitHub search query string. A user who typed a GitHub qualifier (e.g. repo:other/repo, author:someone) into the search field could override the query operators the hook already set, retrieving issues outside the intended username scope.

## Root Cause

The filter value was concatenated without sanitization:
- q += filters.search in:title

A search term containing repo:org/repo would inject an extra repository scope, bypassing the author:-based filter.

## Related Issue

Closes #690

## Type of Change

- [x] Bug fix

## Changes Made

- src/hooks/useGitHubData.ts: Added a sanitize step that strips key:value qualifier patterns from filters.search before appending to the query. Plain keyword searches continue to work as intended.

## Testing Done

1. Search for "fix bug": query builds correctly as before.
2. Search for "repo:other/repo fix": qualifier is stripped, only "fix" is appended.
3. Search for "author:someone": stripped entirely, query not modified.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub search input validation to ensure search queries are processed correctly and prevent unintended query modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->