### PR TITLE
fix(auth): auto-clear session credentials after 30 minutes of inactivity

### DIFF
--- a/src/hooks/useGitHubAuth.ts
+++ b/src/hooks/useGitHubAuth.ts
@@ -1,14 +1,64 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { Octokit } from '@octokit/core';
+
+// Inactivity timeout in milliseconds (30 minutes).
+// If the user has not interacted with the application for this period,
+// the session credentials are cleared automatically. This limits the
+// window during which a stolen or leaked token remains usable.
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
 export const useGitHubAuth = () => {
   const [username, setUsername] = useState('');
   const [token, setToken] = useState('');
 
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear credentials on session expiry.
+  const clearSession = useCallback(() => {
+    setUsername('');
+    setToken('');
+  }, []);
+
+  // Reset the inactivity timer on every interaction.
+  // The timer is only active when a username is set (i.e., a session exists).
+  const resetTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    if (username) {
+      timeoutRef.current = setTimeout(clearSession, SESSION_TIMEOUT_MS);
+    }
+  }, [username, clearSession]);
+
+  useEffect(() => {
+    if (!username) {
+      // No active session; clear any lingering timer.
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      return;
+    }
+
+    const events = ['mousemove', 'keydown', 'click', 'scroll', 'touchstart'];
+
+    // Start the timer immediately when a session begins.
+    resetTimer();
+
+    events.forEach((e) => window.addEventListener(e, resetTimer));
+
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, resetTimer));
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [username, resetTimer]);
+
   const octokit = useMemo(() => {
     if (!username) return null;
-    if(token){
-    return new Octokit({ auth: token });
+    if (token) {
+      return new Octokit({ auth: token });
     }
     return new Octokit();
   }, [username, token]);
@@ -20,6 +70,7 @@ export const useGitHubAuth = () => {
     setUsername,
     token,
     setToken,
+    clearSession,
     getOctokit,
   };
 };


### PR DESCRIPTION
## Description

Sessions had no expiration: once a username and optional PAT were entered they remained in React state for the lifetime of the browser tab. An unattended tab with a PAT in state was exploitable for the entire browser session, and any token compromise provided indefinite access.

## Root Cause

useGitHubAuth used useState for both username and token with no cleanup mechanism. No inactivity timer or session expiry was implemented.

## Related Issue

Closes #688

## Type of Change

- [x] Bug fix (security)

## Changes Made

- src/hooks/useGitHubAuth.ts: Added a 30-minute inactivity timer using useEffect and useRef. After 30 minutes without user interaction the timer calls clearSession(), zeroing both username and token. The timer resets on mousemove, keydown, click, scroll, and touchstart events. The timer is only active while a username is set and is fully cleaned up when the component unmounts or the session is cleared.

## Testing Done

1. Enter username and token: session remains active while the user interacts.
2. Leave browser idle for 30 minutes: credentials are automatically cleared.
3. Active interaction resets the 30-minute window each time.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue