### PR TITLE
fix(auth): prevent browser autofill of PAT field

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -182,6 +182,7 @@ const Home: React.FC = () => {
               onChange={(e) => setToken(e.target.value)}
               type="password"
               required
+              inputProps={{ autoComplete: 'new-password' }}
               sx={{ flex: 1, minWidth: 150 }}
               helperText={
                 <Box


### PR DESCRIPTION
## Description

The Personal Access Token input field did not set an autocomplete attribute. Browsers with saved form data could auto-fill the field with previously stored passwords, potentially placing a credential into the PAT field without the user's intent and without them knowing which credential was filled.

## Root Cause

The TextField for the PAT did not specify inputProps.autoComplete. Browsers default to treating password fields as login credentials and may autofill them from the password manager.

## Related Issue

Closes #687

## Type of Change

- [x] Bug fix (security)

## Changes Made

- src/pages/Tracker/Tracker.tsx: Added inputProps with autoComplete set to new-password on the PAT TextField. This signals to the browser that the field is for entering a new credential rather than filling a saved one. The field already uses type=password for visual masking.

## Testing Done

1. Open the tracker form: browser no longer autofills the PAT field.
2. The field still masks input correctly with type=password.
3. User-typed PAT values work as before.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue