### PR TITLE
Prevent account enumeration via signup error messages (Issue #697)

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -16,14 +16,14 @@ router.post("/signup", validateRequest(signupSchema), async (req, res) => {
         });
 
         if (existingUser)
-            return res.status(400).json({ message: 'User already exists' });
+            return res.status(400).json({ message: 'Username or email is invalid' });
 
         const newUser = new User({ username, email, password });
         await newUser.save();
         res.status(201).json({ message: 'User created successfully' });
     } catch (err) {
         if (err && err.code === 11000) {
-            return res.status(400).json({ message: 'User already exists' });
+            return res.status(400).json({ message: 'Username or email is invalid' });
         }
 
         res.status(500).json({ message: 'Error creating user', error: err.message });


### PR DESCRIPTION
## Summary
Replace specific 'User already exists' error message with generic 'Username or email is invalid' message. This prevents attackers from enumerating valid email addresses and usernames in the system by observing different error messages during signup attempts.

## Changes
- Changed error message on duplicate user detection to generic message
- Changed duplicate key error message to match generic message
- Prevents account enumeration attacks that rely on error message differences

## Testing
1. Attempt to sign up with an existing email address
2. Verify response returns generic error message
3. Attempt to sign up with an existing username
4. Verify response returns same generic error message as email
5. Verify no difference in error messages between existing vs non-existing users

## Type of Change
- Security fix

## Contributor Declaration
This contribution is original work and I have the right to contribute this code to the project. I understand that the project is licensed under its respective license and my contributions will be available under the same license terms.

Closes #697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the error message displayed when attempting to sign up with a duplicate username or email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->