### PR TITLE
Add missing next() call in Mongoose pre-save middleware hook (Issue #699)

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -18,12 +18,12 @@ const UserSchema = new mongoose.Schema({
   },
 });
 
-// ✅ FIXED: no next()
-UserSchema.pre('save', async function () {
-  if (!this.isModified('password')) return;
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
 
   const salt = await bcrypt.genSalt(10);
   this.password = await bcrypt.hash(this.password, salt);
+  next();
 });
 
 // ✅ password comparison


### PR DESCRIPTION
## Summary
Ensure proper middleware chain execution by calling next() in the pre-save hook. This prevents middleware chain interruption and ensures subsequent hooks are invoked correctly.

## Changes
- Added next parameter to pre-save hook
- Call next() when password modification check returns early
- Call next() at end of middleware to allow next hook execution
- Maintains compatibility with Mongoose middleware chain

## Testing
1. Create a new user and verify password hashing works correctly
2. Update an existing user without changing password and verify no re-hashing
3. Update an existing user's password and verify re-hashing occurs
4. Verify subsequent middleware hooks (if any) execute properly
5. Check that no middleware chain errors occur

## Type of Change
- Bug fix

## Contributor Declaration
This contribution is original work and I have the right to contribute this code to the project. I understand that the project is licensed under its respective license and my contributions will be available under the same license terms.

Closes #699