### PR TITLE
Add HTTPS enforcement middleware for production deployments (Issue #701)

### DIFF
--- a/backend/middleware/httpsRedirect.js
+++ b/backend/middleware/httpsRedirect.js
@@ -1,0 +1,10 @@
+const httpsRedirect = (req, res, next) => {
+  if (process.env.NODE_ENV === 'production') {
+    if (req.header('x-forwarded-proto') !== 'https') {
+      return res.redirect(301, `https://${req.header('host')}${req.url}`);
+    }
+  }
+  next();
+};
+
+module.exports = httpsRedirect;

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,8 +10,12 @@ const cors = require('cors');
 require('./config/passportConfig');
 
 const logger = require('./logger');
+const httpsRedirect = require('./middleware/httpsRedirect');
 
 const app = express();
+
+// HTTPS enforcement (must be before other middleware)
+app.use(httpsRedirect);
 
 // CORS configuration
 const allowedOrigins = ['http://localhost:5173', 'https://github-spy.etlify.app'];


### PR DESCRIPTION
## Summary
Implement automatic HTTP to HTTPS redirection in production environments. This ensures that all credentials and sensitive data are transmitted only over encrypted HTTPS connections, preventing man-in-the-middle attacks and credential leaks.

## Changes
- Create httpsRedirect middleware that checks x-forwarded-proto header
- Redirect HTTP requests to HTTPS in production
- Add middleware to server.js before other routes
- Handles reverse proxy scenarios (Netlify, Heroku, etc.)

## Testing
1. Set NODE_ENV=production
2. Make HTTP request to server
3. Verify automatic redirect to HTTPS
4. Verify credentials are transmitted only over HTTPS
5. Test with reverse proxy headers (x-forwarded-proto)
6. Verify localhost development still works without redirect

## Type of Change
- Security fix
- Infrastructure

## Contributor Declaration
This contribution is original work and I have the right to contribute this code to the project. I understand that the project is licensed under its respective license and my contributions will be available under the same license terms.

Closes #701