### PR TITLE
Make Moon icon color dynamic in Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -83,7 +83,7 @@ const Navbar: React.FC = () => {
             {mode === "dark" ? (
               <Sun className="h-5 w-5 text-yellow-400" />
             ) : (
-              <Moon className="h-5 w-5 text-white" />
+              <Moon className="h-5 w-5 text-slate-900 dark:text-white" />  // ✅ Dynamic color
             )}
           </button>
 


### PR DESCRIPTION
### Related Issue
- Closes: #667

### Fix
- Mobile Light Mode (Moon icon visible)
---

### Description

This PR addresses two UI/UX issues reported by users:

#### 1. Dark Mode Icon Not Visible on Mobile Screens
**Problem:** In the mobile navigation menu, the moon icon had `text-white` class which made it invisible on light backgrounds.

---

### How Has This Been Tested?

**Test Environment:**
- Browser: Google Chrome (Version 120+)
- Devices: Desktop (1920x1080), Mobile (iPhone 12, Pixel 5 emulation)
- Themes: Light mode & Dark mode

---

### Screenshots

#### Before Fix - Mobile Light Mode (Moon icon invisible)
<img width="299" height="375" alt="image" src="https://github.com/user-attachments/assets/38394c46-2cb5-41d0-99cf-d8053e73c44f" />


#### After Fix - Mobile Light Mode (Moon icon visible)
<img width="200" height="352" alt="image" src="https://github.com/user-attachments/assets/c5dde7b9-9557-4673-ba30-217a0052bd59" />

---

### Code Changes Summary

**File 1: `src/components/Navbar.tsx`**
```diff
- <Moon className="h-5 w-5 text-white" />
+ <Moon className="h-5 w-5 text-slate-900 dark:text-white" />