### PR TITLE
feat(a11y): add keyboard navigation support (#631)

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -34,7 +34,7 @@ const Hero = () => {
 
             <div className="pt-4 flex flex-wrap gap-4">
               {/* Interactive Primary Link Button */}
-              <Link to='/track' className="group relative inline-flex items-center justify-center p-0.5 overflow-hidden text-sm font-semibold rounded-xl bg-gradient-to-br from-blue-600 via-cyan-500 to-teal-500 dark:from-blue-500 dark:via-cyan-400 dark:to-teal-400 text-slate-900 dark:text-white transition-all shadow-md dark:shadow-[0_0_20px_rgba(59,130,246,0.3)] hover:shadow-lg dark:hover:shadow-[0_0_35px_rgba(34,211,238,0.5)] transform hover:-translate-y-0.5">
+              <Link to='/track' className="group relative inline-flex items-center justify-center p-0.5 overflow-hidden text-sm font-semibold rounded-xl bg-gradient-to-br from-blue-600 via-cyan-500 to-teal-500 dark:from-blue-500 dark:via-cyan-400 dark:to-teal-400 text-slate-900 dark:text-white transition-all shadow-md dark:shadow-[0_0_20px_rgba(59,130,246,0.3)] hover:shadow-lg dark:hover:shadow-[0_0_35px_rgba(34,211,238,0.5)] transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2">
                 <span className="relative px-7 py-3.5 transition-all ease-in duration-75 bg-white dark:bg-[#030712] rounded-[10px] group-hover:bg-opacity-0 flex items-center space-x-2">
                   <Search className="h-5 w-5 text-blue-600 dark:text-cyan-400 group-hover:text-white transition-colors" />
                   <span className="text-slate-900 dark:text-white group-hover:text-white">Start Tracking</span>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -60,7 +60,7 @@ const Navbar: React.FC = () => {
           {/* Theme Toggle */}
           <button
             onClick={toggleTheme}
-            className="ml-2 p-2 rounded-xl border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="ml-2 p-2 rounded-xl border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             aria-label="Toggle Theme"
           >
             {mode === "dark" ? (
@@ -77,7 +77,7 @@ const Navbar: React.FC = () => {
           {/* Theme Toggle */}
           <button
             onClick={toggleTheme}
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             aria-label="Toggle Theme"
           >
             {mode === "dark" ? (
@@ -90,7 +90,7 @@ const Navbar: React.FC = () => {
           {/* Menu Toggle */}
           <button
             onClick={() => setIsOpen(!isOpen)}
-            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             aria-label="Toggle Menu"
           >
             {isOpen ? (

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,13 @@
 .icon-issue-closed {
   color: #cf222e;
 }
+
+/* Keyboard navigation: suppress focus ring for mouse, show for keyboard */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef, useCallback } from "react"
 import {
   IssueOpenedIcon,
   IssueClosedIcon,
@@ -78,6 +78,14 @@ const Home: React.FC = () => {
   const [selectedRepo, setSelectedRepo] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+  const usernameInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUsernameKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+   if (e.key === "Escape") {
+    setUsername("");
+    usernameInputRef.current?.querySelector("input")?.focus();
+   }
+}, [setUsername]);
 
   // Fetch data when username, tab, or page changes
   useEffect(() => {
@@ -173,7 +181,11 @@ const Home: React.FC = () => {
               label="GitHub Username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
+              onKeyDown={handleUsernameKeyDown}
               required
+              autoFocus
+              inputRef={usernameInputRef}
+              inputProps={{ "aria-label": "GitHub Username" }}
               sx={{ flex: 1, minWidth: 150 }}
             />
             <TextField
@@ -292,9 +304,10 @@ const Home: React.FC = () => {
             setPage(0);
           }}
           sx={{ flex: 1 }}
+          aria-label="Data view tabs"
         >
-          <Tab label={`Issues (${totalIssues})`} />
-          <Tab label={`Pull Requests (${totalPrs})`} />
+          <Tab label={`Issues (${totalIssues})`} aria-label={`Issues tab, ${totalIssues} total`}/>
+          <Tab label={`Pull Requests (${totalPrs})`} aria-label={`Pull Requests tab, ${totalPrs} total`} />
         </Tabs>
         <FormControl sx={{ minWidth: 150 }}>
           <InputLabel sx={{ fontSize: "14px" }}>State</InputLabel>


### PR DESCRIPTION
### Related Issue

- Closes: #631

---

### Description

```Added keyboard navigation support across the app so users who rely on keyboard-only navigation (developers using Vimium, users with motor disabilities, power users) can fully use the app.
-autoFocus on the GitHub Username input so users can start typing immediately on page load
-E-cape key clears the username input and returns focus to it
-focus-visible ring added to all Navbar buttons (theme toggle, mobile menu toggle)
-focus-visible ring added to the Hero "Start Tracking" CTA link
-Global :focus-visible CSS in index.css for consistent focus indicators across the app — suppresses outline for mouse users, shows it for keyboard users
-aria-label added to Tabs and Tab components for screen reader support```
---

### How Has This Been Tested?

-Manually tabbed through the entire app in Chrome and verified all interactive elements are reachable and show a visible focus ring
-Verified autoFocus lands on the username input on page load
-Verified Escape clears the input and returns focus
-Verified existing functionality (search, filters, tabs, pagination) is unaffected

---

### Screenshots 

<img width="1902" height="924" alt="image" src="https://github.com/user-attachments/assets/e4c8e3c4-17e8-432f-8c18-48f83d45af82" />


---

### Type of Change

- [Y] New feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced keyboard navigation with improved focus indicators on buttons and form fields for better visibility.
  * Added Escape key support to quickly clear the GitHub username input.
  * Improved form labeling and added descriptive labels for tracker tabs to enhance screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->