### PR TITLE
Added fix: reset scroll position on route navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from "./components/Footer";
 import ScrollProgressBar from "./components/ScrollProgressBar";
 import { Toaster } from "react-hot-toast";
 import Router from "./Routes/Router";
+import ScrollToTop from "./components/ScrollToTop";
 
 const FULLSCREEN_ROUTES = ["/signup", "/login"];
 
@@ -13,6 +14,7 @@ function App() {
 
   return (
       <div className="relative flex flex-col min-h-screen">
+        <ScrollToTop/>
         {!isFullscreen && <ScrollProgressBar />}
 
         {!isFullscreen && <Navbar />}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import {useEffect} from 'react';
+import {useLocation} from 'react-router-dom';
+
+function ScrollToTop() {
+    const location = useLocation();
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    },[location.pathname]);
+
+    return null;
+}
+export default ScrollToTop;

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,6 +1,9 @@
 import {useEffect} from 'react';
 import {useLocation} from 'react-router-dom';
-
+/**
+ * Resets the window scroll position to the top
+ * whenever the route pathname changes.
+ */
 function ScrollToTop() {
     const location = useLocation();
     useEffect(() => {


### PR DESCRIPTION
### Related Issue

* Closes: #743

---

### Description

This PR fixes the issue where footer navigation links could retain the previous scroll position when navigating between routes.

A reusable `ScrollToTop` component was added to ensure that users are automatically taken to the top of the page whenever the route changes.

#### Changes Made

* Added a `ScrollToTop` component using `useLocation` and `useEffect`.
* Implemented automatic scroll reset using `window.scrollTo(0, 0)`.
* Integrated the component into the application layout so it runs on every route change.

---

### How Has This Been Tested?

* Reproduced the issue locally before implementing the fix.
* Verified that the following pages now load from the top after navigation:

  * Contact Us
  * Privacy Policy
  * About
  * Contributors
  * Tracker
* Tested navigation through footer links.
* Tested on desktop browser.
* Tested using mobile device emulation in browser developer tools.
* Confirmed the application builds and runs successfully using `npm run dev`.

---

### Demonstration
Issue reproduction before the fix.

https://github.com/user-attachments/assets/c0ff9b0d-1163-43b8-83dd-84df962112b0


Correct scroll behavior after the fix.

https://github.com/user-attachments/assets/48ee3315-e252-4067-8bd4-3ecc949a66da



---

### Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic scroll-to-top functionality when navigating between pages, ensuring you always start at the top of new content regardless of your current UI state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->