### PR TITLE
Add conditional rendering for empty data state

### DIFF
--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -351,39 +351,43 @@ const Home: React.FC = () => {
               </TableHead>
 
               <TableBody>
-                {currentFilteredData.map((item) => (
-                  <TableRow key={item.id}>
-
-                    <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        {getStatusIcon(item)}
-                        <Link
-                            href={item.html_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            underline="hover"
-                            sx={{ color: theme.palette.primary.main }}
-                        >
-                            {item.title}
-                        </Link>
-                    </TableCell>
-
-
-                    <TableCell align="center">
-                      {item.repository_url.split("/").slice(-1)[0]}
-                    </TableCell>
-
-                    <TableCell align="center">
-                      {item.pull_request?.merged_at ? "merged" : item.state}
-                    </TableCell>
-
-                    <TableCell>{formatDate(item.created_at)}</TableCell>
-
-                  </TableRow>
-                ))}
-              </TableBody>
+                    {currentFilteredData.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} align="center" sx={{ py: 6, color: "text.secondary" }}>
+                          {tab === 0 ? "No issues found for this user" : "No pull requests available"}
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      currentFilteredData.map((item) => (
+                        <TableRow key={item.id}>
+                          <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            {getStatusIcon(item)}
+                            <Link
+                              href={item.html_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              underline="hover"
+                              sx={{ color: theme.palette.primary.main }}
+                            >
+                              {item.title}
+                            </Link>
+                          </TableCell>
+                  
+                          <TableCell align="center">
+                            {item.repository_url.split("/").slice(-1)[0]}
+                          </TableCell>
+                  
+                          <TableCell align="center">
+                            {item.pull_request?.merged_at ? "merged" : item.state}
+                          </TableCell>
+                  
+                          <TableCell>{formatDate(item.created_at)}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
 
             </Table>
-
             <TablePagination
               component="div"
               count={totalCount}

--- a/src/pages/Tracker/Tracker.tsx
+++ b/src/pages/Tracker/Tracker.tsx
@@ -351,41 +351,50 @@ const Home: React.FC = () => {
               </TableHead>
 
               <TableBody>
-                    {currentFilteredData.length === 0 ? (
-                      <TableRow>
-                        <TableCell colSpan={4} align="center" sx={{ py: 6, color: "text.secondary" }}>
-                          {tab === 0 ? "No issues found for this user" : "No pull requests available"}
-                        </TableCell>
-                      </TableRow>
-                    ) : (
-                      currentFilteredData.map((item) => (
-                        <TableRow key={item.id}>
-                          <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            {getStatusIcon(item)}
-                            <Link
-                              href={item.html_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              underline="hover"
-                              sx={{ color: theme.palette.primary.main }}
-                            >
-                              {item.title}
-                            </Link>
-                          </TableCell>
-                  
-                          <TableCell align="center">
-                            {item.repository_url.split("/").slice(-1)[0]}
-                          </TableCell>
-                  
-                          <TableCell align="center">
-                            {item.pull_request?.merged_at ? "merged" : item.state}
-                          </TableCell>
-                  
-                          <TableCell>{formatDate(item.created_at)}</TableCell>
-                        </TableRow>
-                      ))
-                    )}
-                  </TableBody>
+                {totalCount === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center" sx={{ py: 6, color: "text.secondary", textAlign: "center" }}>
+                      {tab === 0 ? "No issues found for this user" : "No pull requests available"}
+                    </TableCell>
+                  </TableRow>
+                ) : 
+               
+                currentFilteredData.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center" sx={{ py: 6, color: "text.secondary", textAlign: "center" }}>
+                      No matches found on this page. Try resetting your filters or changing pages.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                 
+                  currentFilteredData.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        {getStatusIcon(item)}
+                        <Link
+                          href={item.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ color: theme.palette.primary.main }}
+                        >
+                          {item.title}
+                        </Link>
+                      </TableCell>
+              
+                      <TableCell align="center">
+                        {item.repository_url.split("/").slice(-1)[0]}
+                      </TableCell>
+              
+                      <TableCell align="center">
+                        {item.pull_request?.merged_at ? "merged" : item.state}
+                      </TableCell>
+              
+                      <TableCell>{formatDate(item.created_at)}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
 
             </Table>
             <TablePagination


### PR DESCRIPTION
###Related issue 👍 
📜 Description
Hello @mehul-m-prajapati

When searching for a user’s issues or pull requests, if there are no results, the page only shows:
0–0 of 0

This creates a confusing user experience and doesn’t clearly indicate that no issues or PRs exist.

Steps to Reproduce:

Open the Tracker page.

Enter a GitHub username that has no issues/PRs.

Click Fetch Data.

Actual Behavior:
The table displays 0–0 of 0 with no clear explanation.

###solution:

Updated the GitHub Tracker empty state handling. Previously, when a search yielded no results or a user had no issues/PRs, the data table component would display an empty view showing only "0–0 of 0", leading to a confusing user experience.

I implemented conditional rendering inside the `TableBody` component in `Tracker.tsx`. Now, if the fetched data array is empty, it elegantly spans a friendly message across the columns telling the user exactly what happened, dynamically adjusting based on whether they are viewing the Issues or Pull Requests tab.

---

### How Has This Been Tested?

* **Manual Testing:**
* Entered a GitHub username with zero active issues/PRs.
* Verified that navigating to the **Issues** tab correctly displays: `"No issues found for this user"`.
* Verified that navigating to the **Pull Requests** tab correctly displays: `"No pull requests available"`.
* Confirmed that the table formatting, pagination grid, and dark mode theme remain intact and un-broken.



---

### Screenshots 

<img width="938" height="877" alt="image" src="https://github.com/user-attachments/assets/6ab52443-b6da-44a3-b86f-59c39764e93f" />


---

### Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Code style update
* [ ] Breaking change
* [ ] Documentation update

Please count Under GSSoC '26 

Thankyou ,
Aayam




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the tracker table so it now shows a clear “no results” message when there are no matching items.
  * The empty state is now more precise: it shows view-specific messaging for Issues vs. Pull requests, and differentiates between no items at all vs. no matches on the current page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->